### PR TITLE
Adding Support for ArcOS

### DIFF
--- a/ansible/config/arcos.yml
+++ b/ansible/config/arcos.yml
@@ -1,18 +1,13 @@
-
 ---
 - name: Push Candidate Config
   template:
     src: '{{ config_template }}'
-    dest: '/tmp/.{{ inventory_hostname }}.xml'
+    dest: '/tmp/.{{ inventory_hostname }}.txt'
 
 - name: Apply candidate config
   arrcus.arcos.arcos_config:
-    src: "/tmp/.{{ inventory_hostname }}.xml"
+    src: "/tmp/.{{ inventory_hostname }}.txt"
     load_operation: merge
     comment: "initial config pushed by netsim"
-
-- name: Remove temp file
-  file:
-   state: absent
-   path: '/tmp/.{{ inventory_hostname }}.xml'
+    delete_src_file: true
 

--- a/ansible/config/arcos.yml
+++ b/ansible/config/arcos.yml
@@ -1,0 +1,40 @@
+---
+- name: ArcOS config pre 2.10
+  block:
+    - name: Push BGP Candidate config
+      template:
+        src: '{{ config_template }}'
+        dest: '/tmp/.{{ inventory_hostname }}.xml'
+
+    - name: Apply candidate config
+      arcos_config:
+        src: "/tmp/.{{ inventory_hostname }}.xml"
+        load_operation: merge
+        comment: "initial config pushed by netsim"
+
+    - name: Remove temp file
+      file:
+        state: absent
+        path: '/tmp/.{{ inventory_hostname }}.xml'
+
+  when: ansible_version.full < "2.10.0"
+
+- name: ArcOS config 2.10
+  block:
+    - name: Push Candidate Config
+      template:
+        src: '{{ config_template }}'
+        dest: '/tmp/.{{ inventory_hostname }}.xml'
+
+    - name: Apply candidate config
+      arrcus.arcos.arcos_config:
+        src: "/tmp/.{{ inventory_hostname }}.xml"
+        load_operation: merge
+        comment: "initial config pushed by netsim"
+
+    - name: Remove temp file
+      file:
+        state: absent
+        path: '/tmp/.{{ inventory_hostname }}.xml'
+
+  when: ansible_version.full > "2.10.0"

--- a/ansible/config/arcos.yml
+++ b/ansible/config/arcos.yml
@@ -1,40 +1,18 @@
+
 ---
-- name: ArcOS config pre 2.10
-  block:
-    - name: Push BGP Candidate config
-      template:
-        src: '{{ config_template }}'
-        dest: '/tmp/.{{ inventory_hostname }}.xml'
+- name: Push Candidate Config
+  template:
+    src: '{{ config_template }}'
+    dest: '/tmp/.{{ inventory_hostname }}.xml'
 
-    - name: Apply candidate config
-      arcos_config:
-        src: "/tmp/.{{ inventory_hostname }}.xml"
-        load_operation: merge
-        comment: "initial config pushed by netsim"
+- name: Apply candidate config
+  arrcus.arcos.arcos_config:
+    src: "/tmp/.{{ inventory_hostname }}.xml"
+    load_operation: merge
+    comment: "initial config pushed by netsim"
 
-    - name: Remove temp file
-      file:
-        state: absent
-        path: '/tmp/.{{ inventory_hostname }}.xml'
+- name: Remove temp file
+  file:
+   state: absent
+   path: '/tmp/.{{ inventory_hostname }}.xml'
 
-  when: ansible_version.full < "2.10.0"
-
-- name: ArcOS config 2.10
-  block:
-    - name: Push Candidate Config
-      template:
-        src: '{{ config_template }}'
-        dest: '/tmp/.{{ inventory_hostname }}.xml'
-
-    - name: Apply candidate config
-      arrcus.arcos.arcos_config:
-        src: "/tmp/.{{ inventory_hostname }}.xml"
-        load_operation: merge
-        comment: "initial config pushed by netsim"
-
-    - name: Remove temp file
-      file:
-        state: absent
-        path: '/tmp/.{{ inventory_hostname }}.xml'
-
-  when: ansible_version.full > "2.10.0"

--- a/collect-configs.ansible
+++ b/collect-configs.ansible
@@ -20,6 +20,11 @@
       state: directory
     run_once: true
     delegate_to: localhost
+
+  - name: gather ArcOS config
+    include_tasks: vendor_specific_tasks/arcos/collect_config.yml
+    when: ansible_network_os == 'arcos'
+    
   - copy:
       content: "{{ ansible_net_config }}"
       dest: "{{ config_dir }}/{{ inventory_hostname }}.cfg"

--- a/config.ansible
+++ b/config.ansible
@@ -1,4 +1,5 @@
-#!/usr/local/bin/ansible-playbook
+#!/usr/bin/env ansible-playbook
+
 ---
 - name: Deploy device configuration
   hosts: all

--- a/docs/install.md
+++ b/docs/install.md
@@ -66,3 +66,6 @@ Vagrant will be totally confused when it sees something that looks like a Linux 
 config.ssh.shell = "bash"
 config.vm.guest = :freebsd
 ```
+### Notes on Arrcus ArcOS *vagrant-libvirt* Box and Ansible Collections
+Please reach out to your Arrcus Customer Engineering Representative or [Contact Arrcus](https://www.arrcus.com/contact-us) for access to the Arrcus Vagrant Box file and ArcOS Ansible collections.
+

--- a/templates/initial/arcos.j2
+++ b/templates/initial/arcos.j2
@@ -4,14 +4,13 @@ system hostname {{ inventory_hostname }}
 interface loopback0
  enable true
  subinterface 0
-   ipv4 address {{ loopback }} prefix_length 32
+   ipv4 address {{ loopback }} prefix-length 32
 !
-interface {{ mgmt_if|default('ma1') }}
 !
 {% for l in links %}
 interface {{ l.ifname }}
  enable true
  subinterface 0
-   ipv4 address {{ l.ip.split('/')[0] }} prefix_length {{ l.ip.split('/')[1] }}
+   ipv4 address {{ l.ip.split('/')[0] }} prefix-length {{ l.ip.split('/')[1] }}
 !
 {% endfor %}

--- a/templates/initial/arcos.j2
+++ b/templates/initial/arcos.j2
@@ -1,0 +1,17 @@
+system hostname {{ inventory_hostname }}
+!
+!
+interface loopback0
+ enable true
+ subinterface 0
+   ipv4 address {{ loopback }} prefix_length 32
+!
+interface {{ mgmt_if|default('ma1') }}
+!
+{% for l in links %}
+interface {{ l.ifname }}
+ enable true
+ subinterface 0
+   ipv4 address {{ l.ip.split('/')[0] }} prefix_length {{ l.ip.split('/')[1] }}
+!
+{% endfor %}

--- a/templates/vagrant/libvirt/arcos-domain.j2
+++ b/templates/vagrant/libvirt/arcos-domain.j2
@@ -1,8 +1,8 @@
-    {{ name }}.vm.box = "{{ box|default('arrcus/arcos4.1.1') }}"
+    {{ name }}.vm.box = "{{ box|default('arcos/arcos4.1.1') }}"
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
     {{ name }}.ssh.insert_key = false
-    {{ name }}.ssh.username = false
-    {{ name }}.ssh.private_key_path = false
+    {{ name }}.ssh.username = "root"
+    {{ name }}.ssh.password = 'arrcus'
 
     {{ name }}.vm.provider :libvirt do |domain|
       domain.cpus = 2

--- a/templates/vagrant/libvirt/arcos-domain.j2
+++ b/templates/vagrant/libvirt/arcos-domain.j2
@@ -1,0 +1,11 @@
+    {{ name }}.vm.box = "{{ box|default('arrcus/arcos4.1.1') }}"
+    {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    {{ name }}.ssh.insert_key = false
+    {{ name }}.ssh.username = false
+    {{ name }}.ssh.private_key_path = false
+
+    {{ name }}.vm.provider :libvirt do |domain|
+      domain.cpus = 2
+      domain.memory = 4096
+      domain.driver = "kvm"
+    end

--- a/topology-defaults.yml
+++ b/topology-defaults.yml
@@ -69,3 +69,11 @@ devices:
       ansible_ssh_pass: vagrant
       ansible_network_os: eos
       ansible_connection: network_cli
+  arcos:
+    interface_name: swp%d
+    mgmt_if: ma1
+    group_vars:
+      ansible_user: root
+      ansible_ssh_pass: arcos
+      ansible_network_os: arcos
+

--- a/vendor_specific_tasks/arcos/collect_config.yml
+++ b/vendor_specific_tasks/arcos/collect_config.yml
@@ -1,20 +1,8 @@
 ---
 - name: save config
-  arrcus.arcos.arcos_command:
-   commands: "show running-config |  save /tmp/.{{ inventory_hostname }}"
-   encoding: text
+  shell: echo 'show run' | confd_cli
+  register: arcos_run_config
 
-- name: fetch config
-  ansible.builtin.slurp:
-   src: "/tmp/.{{ inventory_hostname }}"
-  register: arcosconfig
-
-- name: set net config for ArcOS
-  ansible.builtin.set_fact:
-    ansible_net_config:  "{{ arcosconfig['content'] | b64decode }}"
-
-- name: remove old backup
-  ansible.builtin.file:
-   path: "/tmp/.{{ inventory_hostname }}"
-   state: absent
+- set_fact:
+    ansible_net_config: "{{ arcos_run_config.stdout }}"
 

--- a/vendor_specific_tasks/arcos/collect_config.yml
+++ b/vendor_specific_tasks/arcos/collect_config.yml
@@ -1,0 +1,20 @@
+---
+- name: save config
+  arrcus.arcos.arcos_command:
+   commands: "show running-config |  save /tmp/.{{ inventory_hostname }}"
+   encoding: text
+
+- name: fetch config
+  ansible.builtin.slurp:
+   src: "/tmp/.{{ inventory_hostname }}"
+  register: arcosconfig
+
+- name: set net config for ArcOS
+  ansible.builtin.set_fact:
+    ansible_net_config:  "{{ arcosconfig['content'] | b64decode }}"
+
+- name: remove old backup
+  ansible.builtin.file:
+   path: "/tmp/.{{ inventory_hostname }}"
+   state: absent
+


### PR DESCRIPTION
Few Notes:

I have followed all the steps on your https://netsim-tools.readthedocs.io/en/latest/platforms.html#contributing-new-devices page.  Thanks for making it straight forward to add a new device type.  This PR passes the tests you laid out in that document.

A customer wishing to use ArcOS nodes in these topologies will need to reach out to their Arrcus Rep for access to both the Vagrant Box file and Ansible collection for ArcOS.   I added a note to that in the install.md file

Since ArcOS doesn't support a gather_facts module, I wrote a quick playbook so the collect configs would still be supported.  Not sure where you wanted to store that so I added a new directory called `vendor_specific_tasks`.  Now that I type that its sort of a terrible name,  so if you need that renamed let me know.