### PR TITLE
adding support for OSPF in ArcOS

### DIFF
--- a/templates/ospf/arcos.j2
+++ b/templates/ospf/arcos.j2
@@ -1,0 +1,19 @@
+{% set pid = ospf.process|default(1) %}
+{% set area = ospf.area|default("0.0.0.0") %}
+
+network-instance default protocol OSPF p{{ pid }}
+  global log-adjacency-changes LOG_ADJ_ENABLE_DETAILED 
+  area {{ area }}
+    interface Loopback0
+    {% for l in links|default([]) %}
+    interface {{ l.ifname }}
+      {% if l.type|default("") == "p2p" %}
+        network-type POINT_TO_POINT_NETWORK
+      {% endif %}
+      {% if l.ospf.cost is defined %}
+        metric {{ l.ospf.cost }}
+      {% endif %}
+    {% endfor %}
+
+       
+  

--- a/templates/provider/virtualbox/arcos-domain.j2
+++ b/templates/provider/virtualbox/arcos-domain.j2
@@ -1,0 +1,9 @@
+    {{ name }}.vm.box = "{{ box }}"
+    {{ name }}.vm.synced_folder ".", "/vagrant", disabled: true
+    {{ name }}.ssh.insert_key = false
+    {{ name }}.ssh.username = "root"
+    {{ name }}.ssh.password = 'arrcus'
+    {{ name }}.vm.provider :virtualbox do |vb|
+      vb.cpus = 2
+      vb.memory = 4096
+    end


### PR DESCRIPTION
Added:
- OSPF config template for OSPF in ArcOS
- VB template for ArcOS VMDK

Currently, no support for unnumbered interfaces in ArcOS.  But I will add when/if that comes.