### PR TITLE
Fix running vSRX under AMD CPUs.

### DIFF
--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -49,8 +49,8 @@ class Provider(Callback):
     return self._default_template_name
 
   def transform(self,topology):
-    if "processor" not in topology:
-      topology["processor"] = platform.processor().split()[0]
+    if "processor" not in topology.defaults:
+      topology.defaults.processor = platform.processor().split()[0]
 
   def dump(self,topology):
     template_path = self.get_template_path()

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -5,6 +5,7 @@
 # Provider class and replacing or augmenting its methods (most commonly, transform)
 #
 
+import platform
 import os
 import sys
 import importlib
@@ -48,7 +49,8 @@ class Provider(Callback):
     return self._default_template_name
 
   def transform(self,topology):
-    pass
+    if "processor" not in topology:
+      topology["processor"] = platform.processor().split()[0]
 
   def dump(self,topology):
     template_path = self.get_template_path()

--- a/netsim/templates/provider/libvirt/vsrx-domain.j2
+++ b/netsim/templates/provider/libvirt/vsrx-domain.j2
@@ -18,4 +18,7 @@
       domain.cpus = 2
       domain.memory = 4096
       domain.disk_bus = "ide"
+      {% if "amd" in processor|lower %}
+      domain.cpu_mode = "custom"
+      {% endif %}
     end

--- a/netsim/templates/provider/libvirt/vsrx-domain.j2
+++ b/netsim/templates/provider/libvirt/vsrx-domain.j2
@@ -18,7 +18,7 @@
       domain.cpus = 2
       domain.memory = 4096
       domain.disk_bus = "ide"
-      {% if "amd" in processor|lower %}
+      {% if "amd" in defaults.processor|lower %}
       domain.cpu_mode = "custom"
       {% endif %}
     end


### PR DESCRIPTION
Optionally add in `domain.cpu_mode = "custom"` in the `vm.provider` section of the Vagrantfile for vSRX VMs. This forces the cpu mode to `qemu64` which seems to work for running vSRXs, although the performance is quite bad.

I'ved used the transform method of the Provider class for this because it seemed a right use case for it. I can move it elsewhere if you want.

Fixes #9 