### PR TITLE
Fix LLDP configuration for Junos

### DIFF
--- a/templates/initial/junos.j2
+++ b/templates/initial/junos.j2
@@ -49,5 +49,6 @@ protocols {
     interface {{ mgmt.ifname|default('fxp0') }} {
       disable;
     }
+    interface all;
   }
 }


### PR DESCRIPTION
My vSRX VMs came up without LLDP enabled. I'm not well versed enough in Junos to know is this is generally applicable so a sanity check there would be great.