### PR TITLE
Expand install libvirt to install Ansible collections

### DIFF
--- a/install.libvirt
+++ b/install.libvirt
@@ -11,6 +11,7 @@
   - name: Install apt dependencies
     apt:
       pkg:
+        - ansible
         - libvirt-dev
         - qemu-kvm
         - vagrant
@@ -29,6 +30,13 @@
         - sshpass
         - jq
     become: yes
+ - name: Install ansible dependencies
+    shell: "ansible-galaxy collection install {{ item }}"
+    register: ansible_installed
+    changed_when: '"already installed" not in ansible_installed.stdout'
+    loop:
+     - junipernetworks.junos
+     - cisco.nxos
   - name: Install vagrant-libvirt Vagrant plugin
     shell: "vagrant plugin install vagrant-libvirt --plugin-version={{ vagrant_libvirt_version }}"
     when: not vagrant_libvirt_installed

--- a/install.libvirt
+++ b/install.libvirt
@@ -30,13 +30,10 @@
         - sshpass
         - jq
     become: yes
- - name: Install ansible dependencies
-    shell: "ansible-galaxy collection install {{ item }}"
-    register: ansible_installed
-    changed_when: '"already installed" not in ansible_installed.stdout'
-    loop:
-     - junipernetworks.junos
-     - cisco.nxos
+  - name: Install ansible dependencies
+    shell: "ansible-galaxy collection install -r requirements.yml"
+    register: galaxy_install
+    changed_when: '"Installing" in galaxy_install.stdout'
   - name: Install vagrant-libvirt Vagrant plugin
     shell: "vagrant plugin install vagrant-libvirt --plugin-version={{ vagrant_libvirt_version }}"
     when: not vagrant_libvirt_installed

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,6 @@
 ---
 collections:
 - name: cisco.ios
-  version: 2.1.0
 - name: cisco.nxos
-  version: 2.2.0
 - name: arista.eos
-  version: 2.1.1
 - name: junipernetworks.junos
-  version: 2.1.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,10 @@
+---
+collections:
+- name: cisco.ios
+  version: 2.1.0
+- name: cisco.nxos
+  version: 2.2.0
+- name: arista.eos
+  version: 2.1.1
+- name: junipernetworks.junos
+  version: 2.1.0


### PR DESCRIPTION
Re #14:

> At least the "legacy" NXOS and Junos modules should be in Ansible distro, so I'm wondering why you don't have them.

Doesn't that have something to do with the introductions of collections in Ansible 2.9? I thought they moved everything but the ansible-base to Ansible galaxy.

> In any case, the change makes perfect sense (and is along the lines of what Ansible team is preaching), but if we do install network device collections, we should do it for all supported devices (+ IOS, EOS).

Fixed. Providing a [requirements.yml](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#install-multiple-collections-with-a-requirements-file) for Ansible collections.

> Also, it looks like the "changed when" test would report no changes when one collection is installed but another one is not (because "already installed" string would be printed).

This is fixed by just using `ansible-galaxy collection install -r requirements.yml`

> Finally, please submit a PR against the dev_0.6.1 branch, not against the master branch.

Of course. I wasn't able to find dev_0.6.1, hence the 0.6.2 as with the other PR.