### PR TITLE
Add support for Mikrotik CHR RouterOS

### DIFF
--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -100,6 +100,7 @@ The Vagrant boxes should have the following names:
 | Cumulus VX             | CumulusCommunity/cumulus-vx |
 | Juniper vSRX 3.0       | juniper/vsrx3      |
 | VyOS                   | vyos/vyos          |
+| Mikrotik CHR RouterOS  | mikrotik/chr       |
 
 The only box currently available on Vagrant Cloud is the Cumulus VX box. Vagrant automatically downloads it whenever you use Cumulus VX in your lab topology.
 
@@ -124,7 +125,9 @@ Cisco Nexus 9300v and Arista vEOS are available as Virtualbox boxes. To use them
 
 Pete Crocker published similar recipe for [Fortinet firewalls](https://blog.petecrocker.com/post/fortinet_vagrant_libvirt/) (not yet supported by *netsim-tools*, PR welcome).
 
-Stefano Sasso published a recipe for creating a [VyOS](https://github.com/ssasso/packer-vyos-vagrant) box using Packer.
+[Stefano Sasso](http://stefano.dscnet.org) published box-building recipes for the following platforms:
+* [VyOS](https://github.com/ssasso/packer-vyos-vagrant)
+* [Mikrotik RouterOS](http://stefano.dscnet.org/a/mikrotik_vagrant/)
 
 **Notes:**
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -15,6 +15,7 @@ The following virtual network devices are supported by *netsim-tools*:
 | Juniper vSRX 3.0       | vsrx               |
 | Nokia SR Linux         | srlinux            |
 | VyOS                   | vyos               |
+| Mikrotik CHR RouterOS  | routeros           |
 
 **Notes:**
 
@@ -64,6 +65,7 @@ You cannot use all supported network devices with all virtualization providers:
 | Juniper vSRX 3.0       | ✅ | ❌ | ❌ |
 | Nokia SR Linux         | ❌ | ❌ | ✅ |
 | VyOS                   | ✅ | ❌ | ❌ |
+| Mikrotik CHR RouterOS  | ✅ | ❌ | ❌ |
 
 **Implementation Caveats**
 
@@ -97,6 +99,7 @@ Ansible playbooks included with **netsim-tools** can deploy and collect device c
 | Juniper vSRX 3.0       | ✅ | ✅ |
 | Nokia SR Linux         | ❌ | ❌ |
 | VyOS                   | ✅ | ✅ |
+| Mikrotik CHR RouterOS  | ✅ | ✅ |
 
 ## Initial Device Configurations
 
@@ -114,10 +117,12 @@ The following system-wide features are configured on supported network operating
 | Juniper vSRX 3.0       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux         | ❌ | ❌ | ❌ | ❌ | ❌ |
 | VyOS                   | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Mikrotik CHR RouterOS  | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 **Caveats:**
 
 * LLDP on Generic Linux is started in Ubuntu VMs but not in Alpine containers.
+* LLDP on Mikrotik CHR RouterOS is enabled on all the interfaces.
 
 The following interface parameters are configured on supported network operating systems as part of initial device configuration:
 
@@ -132,6 +137,7 @@ The following interface parameters are configured on supported network operating
 | Generic Linux          | ✅ | ✅ | ❌ | ❌  | ❌ |
 | Juniper vSRX 3.0       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | VyOS                   | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Mikrotik CHR RouterOS  | ✅ | ✅ | ❌ | ✅ | ❌ |
 
 ## Supported Configuration Modules
 
@@ -150,6 +156,7 @@ Individual **netsim-tools** [configuration modules](module-reference.md) are sup
 | Juniper vSRX 3.0       | ✅ | ✅ | ❌ | ✅ | ❌ |
 | Nokia SR Linux         | ❌ | ❌ | ❌ | ❌ | ❌ |
 | VyOS                   | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Mikrotik CHR RouterOS  | ✅ | ❌ | ❌ | ✅ | ❌ |
 
 ## IPv6 Support
 
@@ -167,6 +174,7 @@ Core functionality of *netsim-tools* and all multi-protocol routing protocol con
 | Generic Linux          | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Juniper vSRX 3.0       | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
 | VyOS                   | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Mikrotik CHR RouterOS  | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 
 ## Host Routing
 

--- a/netsim/ansible/tasks/deploy-config/routeros.yml
+++ b/netsim/ansible/tasks/deploy-config/routeros.yml
@@ -1,0 +1,24 @@
+- local_action:
+    module: tempfile
+    state: file
+    suffix: temp
+    prefix: ansible.{{ inventory_hostname }}.
+  register: tempfile_1
+
+- local_action:
+    module: template
+    src: "{{ config_template }}"
+    dest: "{{ tempfile_1.path }}"
+
+- local_action:
+    module: command
+    cmd: "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i {{ lookup('env', 'HOME') }}/.vagrant.d/insecure_private_key {{ tempfile_1.path }} vagrant@{{ ansible_host }}:config.rsc"
+
+- routeros_command:
+    commands: /import config.rsc
+
+- local_action:
+    module: file
+    path: "{{ tempfile_1.path }}"
+    state: absent
+  when: tempfile_1.path is defined

--- a/netsim/ansible/tasks/fetch-config/routeros.yml
+++ b/netsim/ansible/tasks/fetch-config/routeros.yml
@@ -1,0 +1,7 @@
+---
+- routeros_command:
+    commands: /export
+  register: ros_exp_config
+
+- set_fact:
+    ansible_net_config: "{{ ros_exp_config.stdout_lines[0] | reject('match', '^$') | list | join('\n') }}\n"

--- a/netsim/ansible/templates/bgp/routeros.j2
+++ b/netsim/ansible/templates/bgp/routeros.j2
@@ -1,0 +1,58 @@
+
+/routing bgp instance set 0 as={{ bgp.as }}
+
+{% for n in bgp.neighbors %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+{%     set neigh_id = n[af]|replace('.', '_')|replace(':', '_') %}
+{%     set afi_list = [] %}
+{%     if n['ipv4'] is defined %}
+{{ afi_list.append('ip') }}
+{%     endif %}
+{%     if n['ipv6'] is defined %}
+{{ afi_list.append('ipv6') }}
+{%     endif %}
+
+/routing bgp peer add name={{ neigh_id }} remote-address={{ n[af] }} remote-as={{ n.as }} comment="{{ n.name }}" address-families={{ afi_list|join(',') }}
+{%   if n.type == 'ibgp' %}
+/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] update-source=loopback
+{%   endif %}
+
+{#
+#### NOTE - TODO
+# By Default, routeros has route-reflect=no.
+# THIS MUST BE SET ON THE RR Servers
+# and not on the clients, like it happens on other vendors
+#}
+
+{%    if bgp.next_hop_self is defined and bgp.next_hop_self %}
+/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] nexthop-choice=force-self
+{%    endif %}
+
+{%   endfor %}
+{% endfor %}
+
+{# Set networks to announce #}
+{% for af in ['ipv4','ipv6'] %}
+{%   if bgp[af] is defined %}
+
+{%     if loopback[af] is defined and bgp.advertise_loopback %}
+/routing bgp network add network={{ loopback[af]|ipaddr('0') }}
+{%     endif %}
+
+{%     for l in links|default([]) if l.bgp.advertise|default("") and l[af] is defined %}
+/routing bgp network add network={{ l[af]|ipaddr('0') }}
+{%     endfor %}
+
+{%     for pfx in bgp.originate|default([]) if af == 'ipv4' %}
+/routing bgp network add network={{ pfx|ipaddr('0') }}
+{%     endfor %}
+
+{%   endif %}
+{% endfor %}
+
+{#
+  Add extra IPv4 prefixes
+#}
+{% for pfx in bgp.originate|default([]) %}
+/ip route add type=blackhole dst-address={{ pfx|ipaddr('0') }}
+{% endfor %}

--- a/netsim/ansible/templates/initial/routeros.j2
+++ b/netsim/ansible/templates/initial/routeros.j2
@@ -1,0 +1,30 @@
+
+/system identity set name="{{ inventory_hostname }}"
+
+/interface bridge add name=loopback protocol-mode=none
+
+{% if 'ipv4' in loopback %}
+/ip address add interface=loopback address={{ loopback.ipv4 }}
+{% endif %}
+{% if 'ipv6' in loopback %}
+/ipv6 address add interface=loopback address={{ loopback.ipv6 }}
+{% endif %}
+
+{% for l in links|default([]) %}
+
+{% if l.name is defined %}
+/interface ethernet set comment="{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}" {{ l.ifname }}
+{% elif l.type|default("") == "stub" %}
+/interface ethernet set comment="Stub interface" {{ l.ifname }}
+{% endif %}
+
+{% if 'ipv4' in l %}
+/ip address add interface={{ l.ifname }} address={{ l.ipv4 }}
+{% endif %}
+{% if 'ipv6' in l %}
+/ipv6 address add interface={{ l.ifname }} address={{ l.ipv6 }}
+{% endif %}
+
+{% endfor %}
+
+/ip neighbor discovery-settings set discover-interface-list=all

--- a/netsim/ansible/templates/ospf/routeros.j2
+++ b/netsim/ansible/templates/ospf/routeros.j2
@@ -1,0 +1,58 @@
+
+{% set area = ospf.area|default("0.0.0.0") %}
+
+{#
+  Create AREA list. If default area != 0.0.0.0, append to list
+#}
+{% set area_list = [] %}
+{% if area != '0.0.0.0' %}
+{{ area_list.append(area) }}
+{% endif %}
+{#
+  For each link, check defined area. If != 0.0.0.0, add to area list
+#}
+{% for l in links|default([]) if l.ospf.area is defined %}
+{% if l.ospf.area != '0.0.0.0' %}
+{{ area_list.append(l.ospf.area) }}
+{% endif %}
+{% endfor %}
+
+{#
+  For each unique area, add to area configuration
+#}
+{% for a_def in area_list|unique %}
+/routing ospf area add name={{ a_def }} area-id={{ a_def }}
+{% endfor %}
+
+{% for l in links|default([]) if l.type|default("") == "stub" or l.role|default("NONE") in ["stub","passive"] %}
+/routing ospf interface add interface={{ l.ifname }} passive=yes
+{% endfor %}
+
+/routing ospf interface add interface=loopback passive=yes
+{% if 'ipv4' in loopback %}
+/routing ospf network add area=[/routing ospf area find area-id={{ area }}] network={{ loopback.ipv4 }}
+{% endif %}
+
+{% for l in links|default([]) %}
+{%   if "external" in l.role|default("") %}
+## OSPF not configured on external interface {{ l.ifname }}
+{%   else %}
+
+/routing ospf network add area=[/routing ospf area find area-id={{ l.ospf.area|default(area) }}] network={{ l.ipv4 | ipaddr('subnet') }}
+
+{% set ospf_intf_params=[] %}
+
+{%     if l.type|default("") == "p2p" %}
+{{ ospf_intf_params.append('network-type=point-to-point') }}
+{%     endif %}
+{%     if l.ospf.cost is defined %}
+{{ ospf_intf_params.append('cost='+l.ospfcost) }}
+{%     endif %}
+
+{%     if ospf_intf_params|length > 0 %}
+/routing ospf interface add interface={{ l.ifname }} {{ ospf_intf_params|join(' ') }}
+{%     endif %}
+
+{%   endif %}
+
+{% endfor %}

--- a/netsim/templates/provider/libvirt/routeros-domain.j2
+++ b/netsim/templates/provider/libvirt/routeros-domain.j2
@@ -1,0 +1,13 @@
+    {{ name }}.vm.box = "{{ box }}"
+    {{ name }}.vm.guest = :other
+    {{ name }}.ssh.insert_key = false
+    {{ name }}.ssh.shell = "/ip address print"
+{% if 'box_version' in n  %}
+    {{ name }}.vm.box_version = "{{ n.box_version }}"
+{% endif %}
+    {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+
+    {{ name }}.vm.provider :libvirt do |domain|
+      domain.cpus = 1
+      domain.memory = 256
+    end

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -20,7 +20,7 @@ addressing:
 # Built-in module defaults
 #
 bgp:
-  supported_on: [ cumulus, eos, frr, csr, iosv, nxos, vsrx, vyos ]
+  supported_on: [ cumulus, eos, frr, csr, iosv, nxos, vsrx, vyos, routeros ]
   ebgp_role: external
   advertise_roles: [ stub ]
   advertise_loopback: True
@@ -44,7 +44,7 @@ isis:
     link: [ metric, cost, type ]
 
 ospf:
-  supported_on: [ arcos, cumulus, eos, frr, csr, iosv, nxos, vsrx, vyos ]
+  supported_on: [ arcos, cumulus, eos, frr, csr, iosv, nxos, vsrx, vyos, routeros ]
   attributes:
     global: [ area, process, reference_bandwidth ]
     node: [ area, process, id, reference_bandwidth ]
@@ -273,6 +273,18 @@ devices:
       ansible_connection: paramiko
       ansible_user: vagrant
       ansible_ssh_pass: vagrant
+
+  routeros:
+    interface_name: ether%d
+    mgmt_if: ether1
+    ifindex_offset: 2
+    image:
+      libvirt: mikrotik/chr
+    group_vars:
+      ansible_network_os: routeros
+      ansible_connection: network_cli
+      ansible_user: admin
+      ansible_ssh_pass: admin
 
 #
 # Output settings

--- a/tests/integration/routeros-ospf-multiarea.yml
+++ b/tests/integration/routeros-ospf-multiarea.yml
@@ -1,0 +1,25 @@
+#
+# Mikrotik RouterOS tests - OSPF Multi Area
+#
+
+---
+defaults:
+  device: routeros
+  bgp.as: 65000
+
+module: [ ospf, bgp ]
+
+nodes:
+  r1:
+  r2:
+    bgp.originate: [ 100.64.0.0/24 ]
+
+links:
+- r1:
+  r2:
+- r1:
+  ospf.area: 0.0.0.1
+- r2:
+  ospf.area: 0.0.0.2
+
+

--- a/tests/integration/routeros.yml
+++ b/tests/integration/routeros.yml
@@ -1,0 +1,12 @@
+#
+# Mikrotik RouterOS tests
+#
+defaults:
+  device: routeros
+  bgp:
+    as: 65000
+
+module: [ ospf, bgp ]
+
+nodes: [ s1, s2, s3 ]
+links: [ s1-s2, s2-s3, s1-s2-s3 ]


### PR DESCRIPTION
Support for Mikrotik CHR RouterOS device type, with initial configuration, config check,
bgp and ospf modules. Docs are updated as well.

Vagrant box build instructions by Stefano Sasso has been set as a list
(instead of a single reference).