### PR TITLE
Fortinet support for libvirt

### DIFF
--- a/netsim/templates/provider/libvirt/fortios-domain.j2
+++ b/netsim/templates/provider/libvirt/fortios-domain.j2
@@ -1,0 +1,9 @@
+    {{ name }}.vm.box = "{{ box }}"
+    {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    {{ name }}.ssh.insert_key = false
+
+    {{ name }}.vm.provider :libvirt do |domain|
+      domain.disk_bus = 'ide'
+      domain.cpus = 1
+      domain.memory = 1024
+    end

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -195,6 +195,23 @@ devices:
       ansible_network_os: eos
       ansible_connection: network_cli
 
+  fortios:
+    interface_name: port%d
+    mgmt_if: port1
+    image:
+      libvirt: fortinet/fortios
+    group_vars:
+      ansible_user: admin
+      ansible_password: admin
+      ansible_network_os: fortinet.fortios.fortios
+      ansible_connection: httpapi
+      collections:
+      - fortinet.fortios
+      vdom: "root"
+      ansible_httpapi_use_ssl: no
+      ansible_httpapi_validate_certs: no
+      ansible_httpapi_port: 80
+
   frr:
     interface_name: eth%d
     mgmt_if: eth0


### PR DESCRIPTION
Allow fortios VMs to be spun up via libvirt provider. Note ansible support not in this PR. 