### PR TITLE
Fix: IOS-XE syntax for domain lookup

### DIFF
--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -1,6 +1,6 @@
 hostname {{ inventory_hostname }}
 !
-no ip domain-lookup
+no ip domain lookup
 !
 lldp run
 !


### PR DESCRIPTION
`no ip domain-lookup` command is not available on newer Cisco IOS-XE versions.
The updated command is `no ip domain lookup`, which is available also on older versions.

Tested on:
* 03.15.00.S.155
* 17.03.03