### PR TITLE
WIP: Support link without IP configuration

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -43,6 +43,8 @@ A dictionary describing an individual link contains *node names* as well as *add
 * **role** -- link role, used to select custom addressing pool or specific configuration module behavior.
 * **bandwidth** -- link bandwidth (used to configure interface bandwidth).
 
+If you need a link without any IP configuration (i.e., if you need to test VLANs on it), you can specify **prefix** as *false*.
+
 Links could contain [additional attributes](#custom-attributes-in-node-and-link-data) like *delay* and [module-specific attributes](modules.md#module-specific-node-and-link-attributes). Additional (custom) attributes have to be defined in **defaults.link_attr** list to differentiate them from misspelled node names. 
 
 ### Example

--- a/netsim/addressing.py
+++ b/netsim/addressing.py
@@ -235,7 +235,7 @@ def normalize_af(af: str) -> str:
   return 'ipv4' if af == 'ip' else af
 
 def parse_prefix(prefix: str) -> typing.Dict:
-  if isinstance(prefix,bool) and prefix is False:
+  if not prefix:
     return {}
   supported_af = ['ip','ipv4','ipv6']
   prefix_list: typing.Dict = {}

--- a/netsim/addressing.py
+++ b/netsim/addressing.py
@@ -235,6 +235,8 @@ def normalize_af(af: str) -> str:
   return 'ipv4' if af == 'ip' else af
 
 def parse_prefix(prefix: str) -> typing.Dict:
+  if isinstance(prefix,bool) and prefix is False:
+    return {}
   supported_af = ['ip','ipv4','ipv6']
   prefix_list: typing.Dict = {}
   if isinstance(prefix,dict):

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -1,0 +1,206 @@
+input:
+- topology/input/link-without-prefix.yml
+- package:topology-defaults.yml
+links:
+- left:
+    ifname: Ethernet1
+    ipv4: 10.1.0.1/30
+    node: r1
+  linkindex: 1
+  name: r1 - r2
+  prefix:
+    ipv4: 10.1.0.0/30
+  r1:
+    ipv4: 10.1.0.1/30
+  r2:
+    ipv4: 10.1.0.2/30
+  right:
+    ifname: Ethernet1
+    ipv4: 10.1.0.2/30
+    node: r2
+  type: p2p
+- bridge: input_2
+  linkindex: 2
+  prefix:
+    ipv4: 172.16.0.0/24
+  r1:
+    ipv4: 172.16.0.1/24
+  r2:
+    ipv4: 172.16.0.2/24
+  r3:
+    ipv4: 172.16.0.3/24
+  type: lan
+- left:
+    ifname: Ethernet3
+    node: r1
+  linkindex: 3
+  name: r1 - r2
+  prefix: false
+  r1: {}
+  r2: {}
+  right:
+    ifname: Ethernet3
+    node: r2
+  type: p2p
+- bridge: input_4
+  linkindex: 4
+  prefix: false
+  r1: {}
+  r2: {}
+  r3: {}
+  type: lan
+name: input
+nodes:
+- box: arista/veos
+  device: eos
+  id: 1
+  links:
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 10.1.0.1/30
+    linkindex: 1
+    name: r1 -> r2
+    neighbors:
+      r2:
+        ifname: Ethernet1
+        ipv4: 10.1.0.2/30
+    remote_id: 2
+    remote_ifindex: 1
+    type: p2p
+  - bridge: input_2
+    ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.1/24
+    linkindex: 2
+    name: r1 -> [r2,r3]
+    neighbors:
+      r2:
+        ifname: Ethernet2
+        ipv4: 172.16.0.2/24
+      r3:
+        ifname: Ethernet1
+        ipv4: 172.16.0.3/24
+    type: lan
+  - ifindex: 3
+    ifname: Ethernet3
+    linkindex: 3
+    name: r1 -> r2
+    neighbors:
+      r2:
+        ifname: Ethernet3
+    remote_id: 2
+    remote_ifindex: 3
+    type: p2p
+  - bridge: input_4
+    ifindex: 4
+    ifname: Ethernet4
+    linkindex: 4
+    name: r1 -> [r2,r3]
+    neighbors:
+      r2:
+        ifname: Ethernet4
+      r3:
+        ifname: Ethernet2
+    type: lan
+  loopback:
+    ipv4: 10.0.0.1/32
+  mgmt:
+    ifname: Management1
+    ipv4: 192.168.121.101
+    mac: 08-4F-A9-00-00-01
+  name: r1
+- box: arista/veos
+  device: eos
+  id: 2
+  links:
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 10.1.0.2/30
+    linkindex: 1
+    name: r2 -> r1
+    neighbors:
+      r1:
+        ifname: Ethernet1
+        ipv4: 10.1.0.1/30
+    remote_id: 1
+    remote_ifindex: 1
+    type: p2p
+  - bridge: input_2
+    ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.2/24
+    linkindex: 2
+    name: r2 -> [r1,r3]
+    neighbors:
+      r1:
+        ifname: Ethernet2
+        ipv4: 172.16.0.1/24
+      r3:
+        ifname: Ethernet1
+        ipv4: 172.16.0.3/24
+    type: lan
+  - ifindex: 3
+    ifname: Ethernet3
+    linkindex: 3
+    name: r2 -> r1
+    neighbors:
+      r1:
+        ifname: Ethernet3
+    remote_id: 1
+    remote_ifindex: 3
+    type: p2p
+  - bridge: input_4
+    ifindex: 4
+    ifname: Ethernet4
+    linkindex: 4
+    name: r2 -> [r1,r3]
+    neighbors:
+      r1:
+        ifname: Ethernet4
+      r3:
+        ifname: Ethernet2
+    type: lan
+  loopback:
+    ipv4: 10.0.0.2/32
+  mgmt:
+    ifname: Management1
+    ipv4: 192.168.121.102
+    mac: 08-4F-A9-00-00-02
+  name: r2
+- box: arista/veos
+  device: eos
+  id: 3
+  links:
+  - bridge: input_2
+    ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.0.3/24
+    linkindex: 2
+    name: r3 -> [r1,r2]
+    neighbors:
+      r1:
+        ifname: Ethernet2
+        ipv4: 172.16.0.1/24
+      r2:
+        ifname: Ethernet2
+        ipv4: 172.16.0.2/24
+    type: lan
+  - bridge: input_4
+    ifindex: 2
+    ifname: Ethernet2
+    linkindex: 4
+    name: r3 -> [r1,r2]
+    neighbors:
+      r1:
+        ifname: Ethernet4
+      r2:
+        ifname: Ethernet4
+    type: lan
+  loopback:
+    ipv4: 10.0.0.3/32
+  mgmt:
+    ifname: Management1
+    ipv4: 192.168.121.103
+    mac: 08-4F-A9-00-00-03
+  name: r3
+provider: libvirt

--- a/tests/topology/input/link-without-prefix.yml
+++ b/tests/topology/input/link-without-prefix.yml
@@ -1,0 +1,29 @@
+# Test links without prefix (no IP config)
+#
+defaults:
+  device: eos
+
+nodes:
+- r1
+- r2
+- r3
+
+links:
+
+# P2P link
+- r1-r2
+
+# LAN link
+- [ r1, r2, r3 ]
+
+# P2P link
+- r1:
+  r2:
+  prefix: false
+
+# LAN link
+- r1:
+  r2:
+  r3:
+  prefix: false
+


### PR DESCRIPTION
In certain cases it might be required to have links configured without IP addresses
(and without all the "ip unnumbered" stuff)

With this patch, it should be possible to specify **prefix** as _false_ on the link attributes. With this, the _ipv4_ or _ipv6_ keys will not be present on the link augmented attributes, hence skipping all the IP address configuration part of the templates.

This would be useful i.e. when testing VLANs, or M(c)LAG peer link or - in general - when you want a link but you would like to configure every IP parameter on your own.