### PR TITLE
[WIP] Support Vagrant 2.2.19 and vagrant-libvirt > 0.7.0

### DIFF
--- a/netsim/templates/provider/libvirt/Vagrantfile.j2
+++ b/netsim/templates/provider/libvirt/Vagrantfile.j2
@@ -7,6 +7,9 @@ Vagrant.configure("2") do |config|
     {{ name }}.vm.provider :libvirt do |domain|
       domain.management_network_mac = "{{n.mgmt.mac}}"
       domain.qemu_use_session = false
+      if Gem.loaded_specs['vagrant-libvirt'].version > Gem::Version.new('0.7.0')
+        domain.management_network_keep = true
+      end
     end
 {%   endif %}
 {%  include n.device ~ "-domain.j2" %}

--- a/netsim/templates/provider/libvirt/routeros-domain.j2
+++ b/netsim/templates/provider/libvirt/routeros-domain.j2
@@ -1,5 +1,5 @@
     {{ name }}.vm.box = "{{ box }}"
-    {{ name }}.vm.guest = :other
+    {{ name }}.vm.guest = :freebsd
     {{ name }}.ssh.insert_key = false
     {{ name }}.ssh.shell = "/ip address print"
 {% if 'box_version' in n  %}


### PR DESCRIPTION
**WORK IN PROGRESS _ DO NOT MERGE (yet)**

Starting from vagrant-libvirt version 0.7.0, every network is deleted on vagrant destroy, including the management network.

This behaviour is related to the *always_destroy* parameter default value, which is documented on:
* https://newreleases.io/project/github/vagrant-libvirt/vagrant-libvirt/release/0.7.0
* https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1381

This is not what we want on **netsim-tools**, because the management network is configured on the installation phase with all the DHCP static leases.

A PR has been opened on vagrant-libvirt to have a new option to better control this: https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1425

This PR in netsim-tools allows to use the new proposed option.
A gem version check has been introduced on the Vagrantfile template, so we need to be sure on the vagrant-libvirt version before merging this.

Additionally: the *vm.guest" type *:other* is not usable anymore on newer Vagrant versions. This has been removed from the *routeros* template.
