### PR TITLE
Pre and Post start hooks for libvirt LAB UP

### DIFF
--- a/netsim/cli/up.py
+++ b/netsim/cli/up.py
@@ -23,11 +23,16 @@ def run(cli_args: typing.List[str]) -> None:
   settings = topology.defaults
 
   external_commands.run_probes(settings,topology.provider,2)
-  external_commands.start_lab(settings,topology.provider,3,"netlab up")
 
   provider = providers._Provider.load(topology.provider,topology.defaults.providers[topology.provider])
-  if hasattr(provider,'start_lab') and callable(provider.start_lab):
-    provider.start_lab(topology)
+
+  if hasattr(provider,'pre_start_lab') and callable(provider.pre_start_lab):
+    provider.pre_start_lab(topology)
+
+  external_commands.start_lab(settings,topology.provider,3,"netlab up")
+  
+  if hasattr(provider,'post_start_lab') and callable(provider.post_start_lab):
+    provider.post_start_lab(topology)
 
   external_commands.deploy_configs(4,"netlab up")
 

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -84,5 +84,8 @@ class _Provider(Callback):
     else:
       output.write("\n")
 
-  def start_lab(self, topology: Box) -> None:
+  def post_start_lab(self, topology: Box) -> None:
+    pass
+
+  def pre_start_lab(self, topology: Box) -> None:
     pass

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -5,16 +5,36 @@
 import subprocess
 import re
 from box import Box
+import pathlib
 
 from .. import common
 from . import _Provider
+
+LIBVIRT_MANAGEMENT_NETWORK_NAME = "vagrant-libvirt"
+LIBVIRT_MANAGEMENT_NETWORK_FILE = "templates/provider/libvirt/vagrant-libvirt.xml"
 
 class Libvirt(_Provider):
 
   def transform_node_images(self, topology: Box) -> None:
     self.node_image_version(topology)
 
-  def start_lab(self, topology: Box) -> None:
+  def pre_start_lab(self, topology: Box) -> None:
+    common.print_verbose('pre-start hook for libvirt')
+    # Starting from vagrant-libvirt 0.7.0, the destroy actions deletes all the networking
+    #  including the "vagrant-libvirt" management network.
+    #  Let's re-create it if missing!
+    try:
+      result = subprocess.run(['virsh','net-info',LIBVIRT_MANAGEMENT_NETWORK_NAME],capture_output=True,text=True)
+      if result.returncode == 1:
+        # When ret code is 1, the network is missing
+        common.print_verbose('creating missing %s network' % LIBVIRT_MANAGEMENT_NETWORK_NAME)
+        net_template_xml = pathlib.Path(__file__).parent.parent.joinpath(LIBVIRT_MANAGEMENT_NETWORK_FILE).resolve()
+        result2 = subprocess.run(['virsh','net-define',net_template_xml],capture_output=True,check=True,text=True)
+    except subprocess.CalledProcessError as e:
+      common.error('Exception in net handling for libvirt network %s: [%s] %s' % (LIBVIRT_MANAGEMENT_NETWORK_NAME, e.returncode, e.stderr), module='libvirt')
+    return
+
+  def post_start_lab(self, topology: Box) -> None:
     common.print_verbose('libvirt lab has started, fixing Linux bridges')
     for l in topology.links:
       brname = l.get('bridge',None)

--- a/netsim/templates/provider/libvirt/routeros-domain.j2
+++ b/netsim/templates/provider/libvirt/routeros-domain.j2
@@ -1,5 +1,5 @@
     {{ name }}.vm.box = "{{ box }}"
-    {{ name }}.vm.guest = :other
+    {{ name }}.vm.guest = :freebsd
     {{ name }}.ssh.insert_key = false
     {{ name }}.ssh.shell = "/ip address print"
 {% if 'box_version' in n  %}


### PR DESCRIPTION
Updated code to run pre_start and post_start hooks on **netlab up**.

This is required to have also a check on the libvirt management network bridge (pre_start)
 and creating it if not already present. This is required starting from vagrant-libvirt
 0.7.0, which destroys the bridge at every vagrant destroy.

Additionally: the *vm.guest* type :other is not usable anymore on newer Vagrant versions. This has been removed from the routeros template.

This PR replaces https://github.com/ipspace/netsim-tools/pull/74 .