### PR TITLE
Support new unnumbered style on sros

### DIFF
--- a/netsim/ansible/templates/bfd/sros.gnmi.j2
+++ b/netsim/ansible/templates/bfd/sros.gnmi.j2
@@ -26,7 +26,7 @@
 {% endmacro %}
 
 replace:
-{# { bfd_decl('system' if 'sr' in module else 'Loopback0',loopback) } #}
+{# { bfd_decl('system',loopback) } #}
 {% for l in links|default([]) %}
 {{ bfd_decl('i'+l.ifname,l) }}
 {% endfor %}

--- a/netsim/ansible/templates/initial/sros.gnmi.j2
+++ b/netsim/ansible/templates/initial/sros.gnmi.j2
@@ -30,11 +30,15 @@
 {% if ip_v6|ipv6 %}
 {{ ip_addr('6',ip_v6,name) }}
 {% endif %}
-{% elif l.unnumbered is defined %}
+{% elif l.unnumbered|default(0)|bool or ip_v4 == True or ip_v6 == True %}
+{% if l.unnumbered|default(0)|bool or ip_v4 == True %}
    ipv4:
     unnumbered:
      system: [null]
+{% endif %}
+{% if l.unnumbered|default(0)|bool or ip_v6 == True %}
    ipv6: { }
+{% endif %}
 {% endif %}
 {%- endmacro -%}
 
@@ -66,7 +70,7 @@ updates:
 {% else %}
 {% set portname = l.ifname %}
 {% endif %}
-{% if v4|ipv4 or v6|ipv6 or l.unnumbered|default(0) %}
+{% if v4|ipv4 or v6|ipv6 or l.unnumbered|default(0) or v4==True or v6==True %}
 {{ interface('i'+l.ifname,desc,v4,v6,portname) }}
 {% else %}
 - path: configure/port[port-id={{ portname }}]

--- a/netsim/ansible/templates/initial/sros.gnmi.j2
+++ b/netsim/ansible/templates/initial/sros.gnmi.j2
@@ -50,8 +50,8 @@ updates:
 {% if loopback.ipv4|default('')|ipv4 or 'ipv6' in loopback %}
 {% set v4 = loopback.ipv4|default('') %}
 {% set v6 = loopback.ipv6|default('') %}
-{# The interface name 'system' is special, use generic loopback here instead #}
-{{ interface("system" if 'sr' in module else "Loopback0","loopback interface",v4,v6,'',loopback) }}
+{# The interface name 'system' is special, also used for IP unnumbered #}
+{{ interface("system","system interface",v4,v6,'',loopback) }}
 {% endif %}
 {% for l in links|default([]) %}
 {% set v4 = l.ipv4|default('') %}

--- a/netsim/ansible/templates/isis/srlinux.j2
+++ b/netsim/ansible/templates/isis/srlinux.j2
@@ -23,6 +23,9 @@ updates:
 {%   for l in links|default([]) %}
 {%    if "external" in l.role|default("") %}
      # IS-IS not configured on external interface {{ l.ifname }}
+     - interface-name: {{ l.ifname }}.0
+       admin-state: disable
+       _annotate_admin_state: "Disabled on external interface"
 {%    else %}
      - interface-name: {{ l.ifname }}.0
        circuit-type: {{ 'point-to-point' if l.type|default("") == "p2p" else 'broadcast' }}

--- a/netsim/ansible/templates/isis/sros.gnmi.j2
+++ b/netsim/ansible/templates/isis/sros.gnmi.j2
@@ -11,9 +11,9 @@ updates:
       ipv6-unicast: True
 {%   endif %}
      interface:
-     - interface-name: "{{ "system" if 'sr' in module else "Loopback0" }}"
+     - interface-name: "system"
        passive: True
-{%   for l in links|default([]) if l.ipv4|default('')|ipv4 or l.ipv6|default('')|ipv6 or l.unnumbered|default(False) %}
+{%   for l in links|default([]) if l.ipv4|default('')|bool or l.ipv6|default('')|bool or l.unnumbered|default(False) %}
 {%    if "external" in l.role|default("") %}
      # IS-IS not configured on external interface {{ l.ifname }}
 {%    else %}

--- a/netsim/ansible/templates/ospf/srlinux.j2
+++ b/netsim/ansible/templates/ospf/srlinux.j2
@@ -29,6 +29,11 @@ updates:
 {%     for l in links|default([]) %}
 {%     if "external" in l.role|default("") %}
        # OSPF not configured on external interface {{ l.ifname }}
+       - area-id: {{ l.ospf.area|default(area) }}
+         interface:
+         - interface-name: {{ l.ifname }}.0
+           admin-state: disable
+           _annotate_admin_state: "Disabled due to external interface"
 {%     else %}
        - area-id: {{ l.ospf.area|default(area) }}
          interface:

--- a/netsim/ansible/templates/ospf/sros.gnmi.j2
+++ b/netsim/ansible/templates/ospf/sros.gnmi.j2
@@ -18,7 +18,7 @@ updates:
      area:
      - area-id: "{{ area }}"
        interface:
-       - interface-name: "Loopback0"
+       - interface-name: "system"
          passive: True
 {% for l in links|default([]) if l.type|default("") == "stub" or l.role|default("NONE") in ["stub","passive"] %}
      - area-id: "{{ l.ospf.area|default(area) }}"

--- a/tests/integration/sros-srlinux.yml
+++ b/tests/integration/sros-srlinux.yml
@@ -11,6 +11,12 @@ defaults:
 addressing:
   loopback:
     ipv6: 2001:db8:0::/48
+  core:
+    unnumbered: True # old style
+  unnumbered-ipv4:
+    ipv4: True
+  unnumbered-ipv6:
+    ipv6: True
 
 module: [ ospf, bgp ]
 
@@ -22,5 +28,25 @@ nodes:
   s3:
     device: sros
     license: /Projects/SR_OS_VSR-SIM_license.txt
+  s4:
+    device: sros
+    license: /Projects/SR_OS_VSR-SIM_license.txt
 
-links: [ s1-s2, s1-s3, s2-s3 ]
+links:
+- s1-s2
+- s1-s3
+- s2-s3
+- role: core
+  s3:
+  s4:
+- name: "New style unnumbered ipv4"
+  s3:
+  s4:
+  # ipv4: True not allowed
+  # ipv6: False
+  role: unnumbered-ipv4
+- name: "New style unnumbered ipv6"
+  s3:
+  s4:
+  # ipv6: True
+  role: unnumbered-ipv6


### PR DESCRIPTION
* Change to always use 'system' interface as loopback, needed for unnumbered support
* Also includes annotated config for SR Linux explaining why interfaces are excluded from IGP