### PR TITLE
Cleanup topology defaults for sros and srlinux

### DIFF
--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -49,6 +49,9 @@
 - name: Update SRL node configuration (gNMI SET template={{config_template}},CA={{ansible_root_certificates_file}})
   when: d!=[] or u!=[] or r!=[]
   vars:
+    ansible_port: "{{ srlinux_grpc_port }}" # Uses gNMI over TLS to this port
+    ansible_connection: nokia.grpc.gnmi
+    ansible_gnmi_encoding: JSON_IETF
     cfg: "{{ lookup('file', tempfile_1.path ) | from_yaml }}"
     d: "{{ cfg.delete | default([]) }}"
     u: "{{ cfg.updates | default([]) }}"

--- a/netsim/ansible/tasks/deploy-config/sros.yml
+++ b/netsim/ansible/tasks/deploy-config/sros.yml
@@ -36,10 +36,9 @@
     cfg: "{{ lookup('file', tempfile_1.path ) }}"
   debug: msg="{{ cfg | from_yaml }}"
 
-- name: Wait up to 120s for gNMI(TCP {{ansible_port}}) to be ready on {{ ansible_host }}
-  # vars:
-  #  ansible_connect_timeout: 60 # Increase from default 30
-  wait_for:
+- name: Wait up to 120s for gNMI(TCP {{sros_grpc_port}}) to be ready on {{ ansible_host }}
+  local_action:
+    module: wait_for
     port: "{{ sros_grpc_port }}"
     host: "{{ ansible_host }}"
     connect_timeout: 60

--- a/netsim/ansible/tasks/deploy-config/sros.yml
+++ b/netsim/ansible/tasks/deploy-config/sros.yml
@@ -40,50 +40,56 @@
   # vars:
   #  ansible_connect_timeout: 60 # Increase from default 30
   wait_for:
-    port: "{{ ansible_port }}"
+    port: "{{ sros_grpc_port }}"
     host: "{{ ansible_host }}"
     connect_timeout: 60
     timeout: 120
     sleep: 10 # Wait 10s between attempts
 
 - block:
-  - name: Enable Open Config YAML modules (retry to give Containerlab a chance to finish configuration)
-    when: enable_open_config is not defined
-    tags: [ initial ]
+  - block:
+    - name: Enable Open Config YAML modules (retry to give Containerlab a chance to finish configuration)
+      when: enable_open_config is not defined
+      tags: [ initial ]
+      nokia.grpc.gnmi_config:
+        prefix: configure
+        update:
+        - path: system/management-interface/yang-modules/openconfig-modules
+          val: True # {{ sros_provisioning_model == "sros.openconfig" }}
+      register: enable_open_config
+      retries: 4
+      delay: 15
+      until: enable_open_config is success
+
+    rescue:
+    - name: reset the gNMI connection, then try one more time
+      meta: reset_connection
+
+  - debug: var=enable_open_config
+  # - debug: var=hostvars
+
+  - name: Update node configuration (using gNMI SET based on YAML template {{template_to_use}})
+    when: d or u or r
+    vars:
+      cfg: "{{ lookup('file', tempfile_1.path ) | from_yaml }}"
+      d: "{{ cfg.delete if 'delete' in cfg and cfg.delete is not string else [] }}"
+      u: "{{ cfg.updates if 'updates' in cfg and cfg.updates is not string else [] }}"
+      r: "{{ cfg.replace if 'replace' in cfg and cfg.replace is not string else [] }}"
     nokia.grpc.gnmi_config:
-      prefix: configure
-      update:
-      - path: system/management-interface/yang-modules/openconfig-modules
-        val: True # {{ sros_provisioning_model == "sros.openconfig" }}
-    register: enable_open_config
-    retries: 4
-    delay: 15
-    until: enable_open_config is success
+      # prefix: configure
+      delete: "{{ d }}"
+      replace: "{{ r }}"
+      update: "{{ u }}"
+    register: gnmi_set_result
+    retries: 2
+    until: gnmi_set_result is success
 
-  rescue:
-  - name: reset the gNMI connection, then try one more time
-    meta: reset_connection
+  - debug: var=gnmi_set_result
 
-- debug: var=enable_open_config
-# - debug: var=hostvars
-
-- name: Update node configuration (using gNMI SET based on YAML template {{template_to_use}})
-  when: d or u or r
   vars:
-    cfg: "{{ lookup('file', tempfile_1.path ) | from_yaml }}"
-    d: "{{ cfg.delete if 'delete' in cfg and cfg.delete is not string else [] }}"
-    u: "{{ cfg.updates if 'updates' in cfg and cfg.updates is not string else [] }}"
-    r: "{{ cfg.replace if 'replace' in cfg and cfg.replace is not string else [] }}"
-  nokia.grpc.gnmi_config:
-    # prefix: configure
-    delete: "{{ d }}"
-    replace: "{{ r }}"
-    update: "{{ u }}"
-  register: gnmi_set_result
-  retries: 2
-  until: gnmi_set_result is success
-
-- debug: var=gnmi_set_result
+    ansible_connection: nokia.grpc.gnmi
+    ansible_gnmi_encoding: JSON
+    ansible_port: "{{ sros_grpc_port }}"
 
 # Alternative: ansible.netcommon.cli_command
 # Uses network_cli connection

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -147,23 +147,15 @@ providers:
         provider_kind: srl
         provider_interface_name: e1-%d
         provider_type: ixrd2
-        image:
-          clab: ghcr.io/nokia/srlinux:latest
+        group_vars:
+          srlinux_grpc_port: 57400
 
       sros:
         provider_kind: vr-sros
         provider_interface_name: eth%d
         provider_type: sr-1 # By default emulate SR-1
-        image:
-          clab: vrnetlab/vr-sros:latest
         group_vars:
-          ansible_connection: nokia.grpc.gnmi
-          ansible_network_os: sros # Used internally in netsim-tools only
-          ansible_gnmi_encoding: JSON
-          ansible_port: 57400
-          # ansible_user: admin
-          # ansible_ssh_pass: admin
-          sros_use_openconfig: False # Depends on pending PR for nokia.grpc.gnmi
+          sros_grpc_port: 57400
 
 ports:
   ssh: 22
@@ -331,12 +323,10 @@ devices:
     image:
       clab: ghcr.io/nokia/srlinux
     group_vars:
-      ansible_network_os: srlinux
-      ansible_port: 57400 # Uses gNMI over TLS to this port
-      ansible_connection: nokia.grpc.gnmi
       ansible_user: admin
-      ansible_password: admin
-      ansible_gnmi_encoding: JSON_IETF
+      ansible_ssh_pass: admin
+      ansible_network_os: srlinux
+      ansible_connection: paramiko
     sr:
       srgb_range_start: 500000
       srgb_range_size: 1000
@@ -355,6 +345,7 @@ devices:
       ansible_ssh_pass: admin
       ansible_network_os: sros
       ansible_connection: paramiko_ssh
+      sros_use_openconfig: False # Depends on pending PR for nokia.grpc.gnmi
     sr:
       srgb_range_start: 500000
       srgb_range_size: 1000

--- a/tests/topology/expected/device-global-attr.yml
+++ b/tests/topology/expected/device-global-attr.yml
@@ -29,7 +29,7 @@ module:
 name: input
 nodes:
   l1:
-    box: ghcr.io/nokia/srlinux:latest
+    box: ghcr.io/nokia/srlinux
     device: srlinux
     hostname: clab-input-l1
     id: 1

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -206,7 +206,7 @@ nodes:
       min_rx: 100
       min_tx: 100
       multiplier: 3
-    box: ghcr.io/nokia/srlinux:latest
+    box: ghcr.io/nokia/srlinux
     device: srlinux
     hostname: clab-input-srlinux_r2
     id: 2
@@ -374,7 +374,7 @@ nodes:
       min_rx: 100
       min_tx: 100
       multiplier: 3
-    box: vrnetlab/vr-sros:latest
+    box: vrnetlab/vr-sros
     device: sros
     hostname: clab-input-sros_r1
     id: 1


### PR DESCRIPTION
- Change default ansible connection sros and srlinux, grpc only used for very specific tasks; Ansible sometimes uses the underlying connection at times when it's least expected