### PR TITLE
Initial support for JunOS BFD for OSPF and ISIS

### DIFF
--- a/netsim/ansible/templates/isis/junos.j2
+++ b/netsim/ansible/templates/isis/junos.j2
@@ -17,6 +17,28 @@ protocols {
 {%   if l.isis.passive %}
       passive;
 {%   endif %}
+{%   if l.isis.bfd.ipv4|default(False) %}
+        family inet {
+          bfd-liveness-detection {
+            minimum-receive-interval {{ l.bfd.min_rx|default(bfd.min_rx)|default(500) }};
+            multiplier {{ l.bfd.multiplier|default(bfd.multiplier)|default(3) }};
+            transmit-interval {
+              minimum-interval {{ l.bfd.min_tx|default(bfd.min_tx)|default(500) }};
+            }
+          }
+        }
+{%   endif %}
+{%   if l.isis.bfd.ipv6|default(False) %}
+        family inet6 {
+          bfd-liveness-detection {
+            minimum-receive-interval {{ l.bfd.min_rx|default(bfd.min_rx)|default(500) }};
+            multiplier {{ l.bfd.multiplier|default(bfd.multiplier)|default(3) }};
+            transmit-interval {
+              minimum-interval {{ l.bfd.min_tx|default(bfd.min_tx)|default(500) }};
+            }
+          }
+        }
+{%   endif %}
 {%   if l.isis.metric is defined or l.isis.cost is defined %}
       level 1 metric {{ l.isis.metric|default(l.isis.cost) }};
       level 2 metric {{ l.isis.metric|default(l.isis.cost) }};

--- a/netsim/ansible/templates/ospf/junos.j2
+++ b/netsim/ansible/templates/ospf/junos.j2
@@ -23,6 +23,15 @@ protocols {
 {%   if l.ospf.cost is defined %}
         metric {{ l.ospf.cost }};
 {%   endif %}
+{%   if l.ospf.bfd|default(False) %}
+        bfd-liveness-detection {
+          minimum-receive-interval {{ l.bfd.min_rx|default(bfd.min_rx)|default(500) }};
+          multiplier {{ l.bfd.multiplier|default(bfd.multiplier)|default(3) }};
+          transmit-interval {
+            minimum-interval {{ l.bfd.min_tx|default(bfd.min_tx)|default(500) }};
+          }
+        }
+{%   endif %}
       }
     }
 {% endfor %}


### PR DESCRIPTION
Trying to address #109 for OSPF and IS-IS at protocol level (It seems that BFD on Junos is configurable only on a per-protocol basis / protocol->interface).

Not updating documentation to avoid conflicts with #130.
