### PR TITLE
clab add OVS bridge support

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -28,3 +28,8 @@ To install the Nokia SR OS container image:
 
 * See vrnetlab instructions [here](https://containerlab.srlinux.dev/manual/vrnetlab/)
 * Requires a license
+
+## LAN bridges
+For multi-access network topologies, the tool automatically creates bridges.
+By default a standard Linux bridge is created; for some use cases Openvswitch bridges may work better (e.g. more transparent).
+Configure ```bridge_type: ovs-bridge``` in the topology defaults to use OVS.

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -28,7 +28,7 @@ def create_linux_bridge( brname: str ) -> bool:
       common.error("Error creating bridge '%s': %s" % (brname,ex), module='clab')
       return False
 
-def destroy_linux_bridge( brname: str ):
+def destroy_linux_bridge( brname: str ) -> bool:
     try:
       result = subprocess.run(['sudo','ip','link','del','dev',brname],capture_output=True,check=True,text=True)
       common.print_verbose( f"Delete Linux bridge '{brname}': {result}" )

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -11,31 +11,70 @@ from .. import common
 def list_bridges( topology: Box ) -> typing.Set[str]:
     return { l.bridge for l in topology.links if l.bridge and l.node_count != 2 }
 
+def use_ovs_bridge( topology: Box ) -> bool:
+    return topology.defaults.providers.clab.bridge_type == "ovs-bridge"
+
+def create_linux_bridge( brname: str ) -> bool:
+    try:
+      result = subprocess.run(['sudo','ip','link','add','name',brname,'type','bridge'],capture_output=True,check=True,text=True)
+      common.print_verbose( f"Create Linux bridge '{brname}': {result}" )
+      result2 = subprocess.run(['sudo','ip','link','set','dev',brname,'up'],capture_output=True,check=True,text=True)
+      common.print_verbose( f"Enable Linux bridge '{brname}': {result2}" )
+      result3 = subprocess.run(['sudo','sh','-c',f'echo 65528 >/sys/class/net/{brname}/bridge/group_fwd_mask'],check=True)
+      common.print_verbose( f"Enable LLDP,LACP,802.1X forwarding on Linux bridge '{brname}': {result3}" )
+      return True
+    except Exception as ex:
+      print(ex)
+      common.error("Error creating bridge '%s': %s" % (brname,ex), module='clab')
+      return False
+
+def destroy_linux_bridge( brname: str ):
+    try:
+      result = subprocess.run(['sudo','ip','link','del','dev',brname],capture_output=True,check=True,text=True)
+      common.print_verbose( f"Delete Linux bridge '{brname}': {result}" )
+      return True
+    except Exception as ex:
+      print(ex)
+      common.error("Error deleting Linux bridge '%s': %s" % (brname,ex), module='clab')
+      return False
+
+def create_ovs_bridge( brname: str ) -> bool:
+    try:
+      result = subprocess.run(['sudo','ovs-vsctl','add-br',brname],capture_output=True,check=True,text=True)
+      common.print_verbose( f"Create OVS bridge '{brname}': {result}" )
+      return True
+    except Exception as ex:
+      print(ex)
+      common.error("Error deleting OVS bridge '%s': %s" % (brname,ex), module='clab')
+      return False
+
+def destroy_ovs_bridge( brname: str ) -> bool:
+    try:
+      result = subprocess.run(['sudo','ovs-vsctl','del-br',brname],capture_output=True,check=True,text=True)
+      common.print_verbose( f"Delete OVS bridge '{brname}': {result}" )
+      return True
+    except Exception as ex:
+      print(ex)
+      common.error("Error deleting OVS bridge '%s': %s" % (brname,ex), module='clab')
+      return False
+
 class Containerlab(_Provider):
 
   def augment_node_data(self, node: Box, topology: Box) -> None:
     node.hostname = "clab-%s-%s" % (topology.name,node.name)
 
   def pre_start_lab(self, topology: Box) -> None:
-    common.print_verbose('pre-start hook for Containerlab')
+    common.print_verbose('pre-start hook for Containerlab - create any bridges')
     for brname in list_bridges(topology):
-        try:
-          result = subprocess.run(['sudo','ip','link','add','name',brname,'type','bridge'],capture_output=True,check=True,text=True)
-          common.print_verbose( f"Create Linux bridge '{brname}': {result}" )
-          result2 = subprocess.run(['sudo','ip','link','set','dev',brname,'up'],capture_output=True,check=True,text=True)
-          common.print_verbose( f"Enable Linux bridge '{brname}': {result2}" )
-        except Exception as ex:
-          print(ex)
-          common.error("Error creating bridge '%s': %s" % (brname,ex), module='clab')
-          continue
+        if use_ovs_bridge(topology):
+            create_ovs_bridge(brname)
+        else:
+            create_linux_bridge(brname)
 
   def post_stop_lab(self, topology: Box) -> None:
     common.print_verbose('post-stop hook for Containerlab, cleaning up any bridges')
     for brname in list_bridges(topology):
-        try:
-          result = subprocess.run(['sudo','ip','link','del','dev',brname],capture_output=True,check=True,text=True)
-          common.print_verbose( f"Delete Linux bridge '{brname}': {result}" )
-        except Exception as ex:
-          print(ex)
-          common.error("Error deleting bridge '%s': %s" % (brname,ex), module='clab')
-          continue
+        if use_ovs_bridge(topology):
+            destroy_ovs_bridge(brname)
+        else:
+            destroy_linux_bridge(brname)

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -33,9 +33,10 @@ topology:
 
 {% if links %}
 {# Define bridges for links with less (stub) or more than 2 nodes #}
+{% set bridge_type = defaults.providers.clab.bridge_type|default('bridge') %}
 {% for b in links|rejectattr('node_count','eq',2)|map(attribute='bridge')|unique %}
     {{ b }}:
-      kind: bridge
+      kind: {{ bridge_type }}
 {% endfor %}
 
   links:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -113,7 +113,8 @@ providers:
     # Preserve env to allow user to configure PATH
     start: sudo -E containerlab deploy -t clab.yml
     stop: sudo -E containerlab destroy --cleanup -t clab.yml
-    probe: [ containerlab version ]
+    probe: [ "containerlab version" ]
+    bridge_type: ovs-bridge
     devices:
       eos:
         provider_interface_name: eth%d
@@ -425,8 +426,8 @@ devices:
           unnumbered: True
         ipv6:
           lla: True
-#      ospf:
-#        unnumbered: True
+      ospf:
+        unnumbered: True
       isis:
         unnumbered:
           ipv4: True

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -114,7 +114,7 @@ providers:
     start: sudo -E containerlab deploy -t clab.yml
     stop: sudo -E containerlab destroy --cleanup -t clab.yml
     probe: [ "containerlab version" ]
-    bridge_type: ovs-bridge
+    bridge_type: bridge # Use 'ovs-bridge' to create Openvswitch bridges
     devices:
       eos:
         provider_interface_name: eth%d


### PR DESCRIPTION
Also modifies the Linux bridges to forward LLDP, LACP, 802.1X and other multicast protocols

Use case for OVS: OSPF over multi-access, for some reason the Linux bridge does not forward Hello packets

Default to Linux standard bridges, OVS requires separate package