### PR TITLE
Bug fix: fortinet ospf area id now correctly set

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -13,18 +13,6 @@
 
 * *FortiOS* VM images by default have a 15 day evaluation license. The VM has [limited capabilities](https://docs.fortinet.com/document/fortigate-private-cloud/6.0.0/fortigate-vm-on-kvm/504166/fortigate-vm-virtual-appliance-evaluation-license) without a license file. It will work for 15 days from first boot, at which point you must install a license file or recreate the vagrant box completely from scratch.
 * Ansible automation of FortiOS requires the installation of the [FortiOS Ansible Collection 2.1.3 or greater](https://galaxy.ansible.com/fortinet/fortios) and a FortiOS version > 6.0.
-* Ansible configuration of OSPF is currently broken due to a [suspected bug](https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/150) in the FortiOS Ansible Collection. To work around this issue, you must manually configure a OSPF network statement by logging in to the device after initial provisioning. For example:
-
-```bash
-vagrant ssh fw
-config router ospf
-config network
-edit 1
-set area 0.0.0.1
-set prefix 0.0.0.0/0
-end
-end
-```
 
 ## FRR
 

--- a/netsim/ansible/tasks/fortinet.fortios.fortios/initial.yml
+++ b/netsim/ansible/tasks/fortinet.fortios.fortios/initial.yml
@@ -55,34 +55,34 @@
     vdom: "{{ vdom }}"
     state: "present"
     system_interface:
-      alias: '{{ link.name.replace(">","-") | default(omit) }}'
-      estimated_upstream_bandwidth: "{{ link.bandwidth | default(omit) }}"
-      estimated_downstream_bandwidth: "{{ link.bandwidth | default(omit) }}"
-      interface: "{{ link.ifname }}"
-      ip: "{{ link.ipv4 | default(omit) }}"
+      alias: '{{ interface.name.replace(">","-") | default(omit) }}'
+      estimated_upstream_bandwidth: "{{ interface.bandwidth | default(omit) }}"
+      estimated_downstream_bandwidth: "{{ interface.bandwidth | default(omit) }}"
+      interface: "{{ interface.ifname }}"
+      ip: "{{ interface.ipv4 | default(omit) }}"
       lldp_reception: "enable"
       lldp_transmission: "enable"
       mode: "static"
-      name: "{{ link.ifname }}"
-      macaddr: "52:dc:ca:fe:{{ id }}:{{ link.ifindex }}"
+      name: "{{ interface.ifname }}"
+      macaddr: "52:dc:ca:fe:{{ id }}:{{ interface.ifindex }}"
       type: "physical"
       vdom: "{{ vdom }}"
-  with_items: "{{ links }}"
+  with_items: "{{ interfaces }}"
   loop_control:
-    loop_var: link
+    loop_var: interface
 
 - name: Configure interface ipv6 addresses
   fortinet.fortios.fortios_system_interface:
     vdom: "{{ vdom }}"
     state: "present"
     system_interface:
-      interface: "{{ link.ifname }}"
+      interface: "{{ interface.ifname }}"
       ipv6:
-        ip6_address: "{{ link.ipv6 }}"
+        ip6_address: "{{ interface.ipv6 }}"
         ip6_mode: "static"
-      name: "{{ link.ifname }}"
+      name: "{{ interface.ifname }}"
       vdom: "{{ vdom }}"
-  with_items: "{{ links }}"
-  when: link.ipv6 is defined
+  with_items: "{{ interfaces }}"
+  when: interface.ipv6 is defined
   loop_control:
-    loop_var: link
+    loop_var: interface

--- a/netsim/ansible/tasks/fortinet.fortios.fortios/ospf.yml
+++ b/netsim/ansible/tasks/fortinet.fortios.fortios/ospf.yml
@@ -4,8 +4,7 @@
     vdom: "{{ vdom }}"
     router_ospf:
       area:
-        -
-          id: "{{ ospf.area | ansible.netcommon.ipaddr('address') | default('0.0.0.0') }}"
+        - id: "{{ ospf.area | ansible.netcommon.ipaddr('address') | default('0.0.0.0') }}"
       auto_cost_ref_bandwidth: "{{ ospf.reference_bandwidth | default(omit) }}"
       router_id: "{{ loopback.ipv4 | ipaddr('address') | default(omit) }}"
 
@@ -14,8 +13,7 @@
     vdom: "{{ vdom }}"
     router_ospf:
       ospf_interface:
-        -
-          name: "loopback0"
+        - name: "loopback0"
           interface: "loopback0"
 
 - name: Configure OSPF on non ptp interfaces
@@ -23,63 +21,55 @@
     vdom: "{{ vdom }}"
     router_ospf:
       ospf_interface:
-        -
-          name: "{{ link.ifname }}"
-          interface: "{{ link.ifname }}"
-  with_items: "{{ links }}"
-  when: link.type != "ptp" and not (link.role is defined and link.role == "external")
+        - name: "{{ interface.ifname }}"
+          interface: "{{ interface.ifname }}"
+  with_items: "{{ interfaces }}"
+  when: interface.type != "ptp" and not (interface.role is defined and interface.role == "external")
   loop_control:
-    loop_var: link
+    loop_var: interface
 
 - name: Configure OSPF on ptp interfaces
   fortinet.fortios.fortios_router_ospf:
     vdom: "{{ vdom }}"
     router_ospf:
       ospf_interface:
-        -
-          name: "{{ link.ifname }}"
-          interface: "{{ link.ifname }}"
+        - name: "{{ interface.ifname }}"
+          interface: "{{ interface.ifname }}"
           network_type: "point-to-point"
-  with_items: "{{ links }}"
-  when: link.type == "ptp" and not (link.role is defined and link.role == "external")
+  with_items: "{{ interfaces }}"
+  when: interface.type == "ptp" and not (interface.role is defined and interface.role == "external")
   loop_control:
-    loop_var: link
+    loop_var: interface
 
 - name: Configure OSPF on passive interfaces
   fortinet.fortios.fortios_router_ospf:
     vdom: "{{ vdom }}"
     router_ospf:
       passive_interface:
-        -
-          name: "{{ link.ifname }}"
-          interface: "{{ link.ifname }}"
-  with_items: "{{ links }}"
-  when: (link.type is defined and link.type == "stub") or (link.role is defined and link.role in ["stub","passive"])
+        - name: "{{ interface.ifname }}"
+          interface: "{{ interface.ifname }}"
+  with_items: "{{ interfaces }}"
+  when: (interface.type is defined and interface.type == "stub") or (interface.role is defined and interface.role in ["stub","passive"])
   loop_control:
-    loop_var: link
+    loop_var: interface
 
 - name: Configure OSPF interface cost
   fortinet.fortios.fortios_router_ospf:
     vdom: "{{ vdom }}"
     router_ospf:
       ospf_interface:
-        -
-          name: "{{ link.ifname }}"
-          cost: "{{ link.ospf.cost }}"
-  with_items: "{{ links }}"
-  when: link.ospf.cost is defined
+        - name: "{{ interface.ifname }}"
+          cost: "{{ interface.ospf.cost }}"
+  with_items: "{{ interfaces }}"
+  when: interface.ospf.cost is defined
   loop_control:
-    loop_var: link
+    loop_var: interface
 
-# Currently not working due to suspected bug:
-# https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/150
-# Note: OSPF neighbors won't attempt to establish without network statement
-#
-#- name: Configure OSPF network statement
-#  fortinet.fortios.fortios_router_ospf:
-#    vdom: "{{ vdom }}"
-#    router_ospf:
-#      network:
-#        area: "{{ ospf.area | ansible.netcommon.ipaddr('address') | default('0.0.0.0') }}"
-#        id: 1
-#        prefix: "{{ ospf.network | default('0.0.0.0/0') }}"
+- name: Configure OSPF network statement
+  fortinet.fortios.fortios_router_ospf:
+    vdom: "{{ vdom }}"
+    router_ospf:
+      network:
+        - area: "{{ ospf.area | ansible.netcommon.ipaddr('address') | default('0.0.0.0') }}"
+          id: 1
+          prefix: "{{ ospf.network | default('0.0.0.0/0') }}"


### PR DESCRIPTION
Bug fix for Fortinet OSPF:
- Removed caveat from caveats.md
- Corrected fortinet ansible templates to use `interfaces` instead of `links`
- Uncommented fortinet ansible task _Configure OSPF network statement_ now that it's got correct syntax and works

Tested this on the example topology called fortinet.yml