### PR TITLE
Platforms: Cumulus ip unnumbered support

### DIFF
--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -70,10 +70,18 @@ interface {{ l.ifname }}
  description Stub interface
 {% endif %}
 {% if l.ipv4 is defined %}
+{%   if l.ipv4 == True %}
+ ip address {{ loopback.ipv4 }}
+{%   else %}
  ip address {{ l.ipv4 }}
+{%   endif %}
 {% endif %}
 {% if l.ipv6 is defined %}
+{%   if l.ipv6 == True %}
+ ip address {{ loopback.ipv6 }}
+{%   else %}
  ipv6 address {{ l.ipv6 }}
+{%   endif %}
  ipv6 nd ra-interval 5
  no ipv6 nd suppress-ra
 {% endif %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -384,6 +384,14 @@ devices:
       ansible_ssh_pass: vagrant
       ansible_network_os: cumulus
       ansible_connection: paramiko
+    features:
+      initial:
+        ipv4:
+          unnumbered: True
+        ipv6:
+          lla: True
+      ospf:
+        unnumbered: True
 
   srlinux:
     mgmt_if: mgmt0

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -124,7 +124,7 @@ nodes:
         ipv6: true
         node: n_cumulus
       remote_id: 4
-      remote_ifindex: 1
+      remote_ifindex: 2
       role: core
       type: p2p
       unnumbered: true
@@ -226,7 +226,7 @@ nodes:
     id: 4
     interfaces:
     - bridge: input_1
-      ifindex: 0
+      ifindex: 1
       ifname: swp1
       ipv4: 172.19.0.4/24
       ipv6: 2001:db8:1::4/64
@@ -246,7 +246,7 @@ nodes:
         ipv6: 2001:db8:1::3/64
         node: j_vsrx
       type: lan
-    - ifindex: 1
+    - ifindex: 2
       ifname: swp2
       ipv4: true
       ipv6: true
@@ -264,7 +264,7 @@ nodes:
       unnumbered: true
     loopback:
       ipv4: 172.18.1.4/32
-      ipv6: 2001:db8:0:3::4/64
+      ipv6: 2001:db8:0:4::1/64
     mgmt:
       ifname: eth0
       ipv4: 192.168.121.104

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -1,47 +1,73 @@
 input:
-- topology/input/unnumbered.yml
-- package:topology-defaults.yml
+  - topology/input/unnumbered.yml
+  - package:topology-defaults.yml
 links:
-- bridge: input_1
-  interfaces:
-  - ipv4: 172.19.0.1/24
-    ipv6: 2001:db8:1::1/64
-    node: c_nxos
-  - ipv4: 172.19.0.2/24
-    ipv6: 2001:db8:1::2/64
-    node: a_eos
-  - ipv4: 172.19.0.3/24
-    ipv6: 2001:db8:1::3/64
-    node: j_vsrx
-  linkindex: 1
-  node_count: 3
-  prefix:
-    ipv4: 172.19.0.0/24
-    ipv6: 2001:db8:1::/64
-  type: lan
-- interfaces:
-  - ipv4: true
-    ipv6: true
-    node: a_eos
-  - ipv4: true
-    ipv6: true
-    node: c_nxos
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    ipv6: true
-    node: a_eos
-  linkindex: 2
-  name: a_eos - c_nxos
-  node_count: 2
-  right:
-    ifname: Ethernet1/2
-    ipv4: true
-    ipv6: true
-    node: c_nxos
-  role: core
-  type: p2p
-  unnumbered: true
+  - bridge: input_1
+    interfaces:
+      - ipv4: 172.19.0.1/24
+        ipv6: 2001:db8:1::1/64
+        node: c_nxos
+      - ipv4: 172.19.0.2/24
+        ipv6: 2001:db8:1::2/64
+        node: a_eos
+      - ipv4: 172.19.0.3/24
+        ipv6: 2001:db8:1::3/64
+        node: j_vsrx
+      - ipv4: 172.19.0.4/24
+        ipv6: 2001:db8:1::4/64
+        node: n_cumulus
+    linkindex: 1
+    node_count: 4
+    prefix:
+      ipv4: 172.19.0.0/24
+      ipv6: 2001:db8:1::/64
+    type: lan
+  - interfaces:
+      - ipv4: true
+        ipv6: true
+        node: a_eos
+      - ipv4: true
+        ipv6: true
+        node: c_nxos
+    left:
+      ifname: Ethernet2
+      ipv4: true
+      ipv6: true
+      node: a_eos
+    linkindex: 2
+    name: a_eos - c_nxos
+    node_count: 2
+    right:
+      ifname: Ethernet1/2
+      ipv4: true
+      ipv6: true
+      node: c_nxos
+    role: core
+    type: p2p
+    unnumbered: true
+  - interfaces:
+      - ipv4: true
+        ipv6: true
+        node: a_eos
+      - ipv4: true
+        ipv6: true
+        node: n_cumulus
+    left:
+      ifname: Ethernet3
+      ipv4: true
+      ipv6: true
+      node: a_eos
+    linkindex: 3
+    name: a_eos - c_nxos
+    node_count: 2
+    right:
+      ifname: swp2
+      ipv4: true
+      ipv6: true
+      node: n_cumulus
+    role: core
+    type: p2p
+    unnumbered: true
 name: input
 nodes:
   a_eos:
@@ -49,39 +75,59 @@ nodes:
     device: eos
     id: 2
     interfaces:
-    - bridge: input_1
-      ifindex: 1
-      ifname: Ethernet1
-      ipv4: 172.19.0.2/24
-      ipv6: 2001:db8:1::2/64
-      linkindex: 1
-      name: a_eos -> [c_nxos,j_vsrx]
-      neighbors:
-      - ifname: Ethernet1/1
-        ipv4: 172.19.0.1/24
-        ipv6: 2001:db8:1::1/64
-        node: c_nxos
-      - ifname: ge-0/0/0
-        ipv4: 172.19.0.3/24
-        ipv6: 2001:db8:1::3/64
-        node: j_vsrx
-      type: lan
-    - ifindex: 2
-      ifname: Ethernet2
-      ipv4: true
-      ipv6: true
-      linkindex: 2
-      name: a_eos -> c_nxos
-      neighbors:
-      - ifname: Ethernet1/2
+      - bridge: input_1
+        ifindex: 1
+        ifname: Ethernet1
+        ipv4: 172.19.0.2/24
+        ipv6: 2001:db8:1::2/64
+        linkindex: 1
+        name: a_eos -> [c_nxos,j_vsrx,n_cumulus]
+        neighbors:
+          - ifname: Ethernet1/1
+            ipv4: 172.19.0.1/24
+            ipv6: 2001:db8:1::1/64
+            node: c_nxos
+          - ifname: ge-0/0/0
+            ipv4: 172.19.0.3/24
+            ipv6: 2001:db8:1::3/64
+            node: j_vsrx
+          - ifname: swp1
+            ipv4: 172.19.0.4/24
+            ipv6: 2001:db8:1::4/64
+            node: n_cumulus
+        type: lan
+      - ifindex: 2
+        ifname: Ethernet2
         ipv4: true
         ipv6: true
-        node: c_nxos
-      remote_id: 1
-      remote_ifindex: 2
-      role: core
-      type: p2p
-      unnumbered: true
+        linkindex: 2
+        name: a_eos -> c_nxos
+        neighbors:
+          - ifname: Ethernet1/2
+            ipv4: true
+            ipv6: true
+            node: c_nxos
+        remote_id: 1
+        remote_ifindex: 2
+        role: core
+        type: p2p
+        unnumbered: true
+      - ifindex: 3
+        ifname: Ethernet3
+        ipv4: true
+        ipv6: true
+        linkindex: 3
+        name: a_eos -> n_cumulus
+        neighbors:
+          - ifname: swp2
+            ipv4: true
+            ipv6: true
+            node: n_cumulus
+        remote_id: 4
+        remote_ifindex: 1
+        role: core
+        type: p2p
+        unnumbered: true
     loopback:
       ipv4: 172.18.1.2/32
       ipv6: 2001:db8:0:2::1/64
@@ -95,39 +141,43 @@ nodes:
     device: nxos
     id: 1
     interfaces:
-    - bridge: input_1
-      ifindex: 1
-      ifname: Ethernet1/1
-      ipv4: 172.19.0.1/24
-      ipv6: 2001:db8:1::1/64
-      linkindex: 1
-      name: c_nxos -> [a_eos,j_vsrx]
-      neighbors:
-      - ifname: Ethernet1
-        ipv4: 172.19.0.2/24
-        ipv6: 2001:db8:1::2/64
-        node: a_eos
-      - ifname: ge-0/0/0
-        ipv4: 172.19.0.3/24
-        ipv6: 2001:db8:1::3/64
-        node: j_vsrx
-      type: lan
-    - ifindex: 2
-      ifname: Ethernet1/2
-      ipv4: true
-      ipv6: true
-      linkindex: 2
-      name: c_nxos -> a_eos
-      neighbors:
-      - ifname: Ethernet2
+      - bridge: input_1
+        ifindex: 1
+        ifname: Ethernet1/1
+        ipv4: 172.19.0.1/24
+        ipv6: 2001:db8:1::1/64
+        linkindex: 1
+        name: c_nxos -> [a_eos,j_vsrx,n_cumulus]
+        neighbors:
+          - ifname: Ethernet1
+            ipv4: 172.19.0.2/24
+            ipv6: 2001:db8:1::2/64
+            node: a_eos
+          - ifname: ge-0/0/0
+            ipv4: 172.19.0.3/24
+            ipv6: 2001:db8:1::3/64
+            node: j_vsrx
+          - ifname: swp1
+            ipv4: 172.19.0.4/24
+            ipv6: 2001:db8:1::4/64
+            node: n_cumulus
+        type: lan
+      - ifindex: 2
+        ifname: Ethernet1/2
         ipv4: true
         ipv6: true
-        node: a_eos
-      remote_id: 2
-      remote_ifindex: 2
-      role: core
-      type: p2p
-      unnumbered: true
+        linkindex: 2
+        name: c_nxos -> a_eos
+        neighbors:
+          - ifname: Ethernet2
+            ipv4: true
+            ipv6: true
+            node: a_eos
+        remote_id: 2
+        remote_ifindex: 2
+        role: core
+        type: p2p
+        unnumbered: true
     loopback:
       ipv4: 172.18.1.1/32
       ipv6: 2001:db8:0:1::1/64
@@ -141,23 +191,27 @@ nodes:
     device: vsrx
     id: 3
     interfaces:
-    - bridge: input_1
-      ifindex: 0
-      ifname: ge-0/0/0
-      ipv4: 172.19.0.3/24
-      ipv6: 2001:db8:1::3/64
-      linkindex: 1
-      name: j_vsrx -> [c_nxos,a_eos]
-      neighbors:
-      - ifname: Ethernet1/1
-        ipv4: 172.19.0.1/24
-        ipv6: 2001:db8:1::1/64
-        node: c_nxos
-      - ifname: Ethernet1
-        ipv4: 172.19.0.2/24
-        ipv6: 2001:db8:1::2/64
-        node: a_eos
-      type: lan
+      - bridge: input_1
+        ifindex: 0
+        ifname: ge-0/0/0
+        ipv4: 172.19.0.3/24
+        ipv6: 2001:db8:1::3/64
+        linkindex: 1
+        name: j_vsrx -> [c_nxos,a_eos,n_cumulus]
+        neighbors:
+          - ifname: Ethernet1/1
+            ipv4: 172.19.0.1/24
+            ipv6: 2001:db8:1::1/64
+            node: c_nxos
+          - ifname: Ethernet1
+            ipv4: 172.19.0.2/24
+            ipv6: 2001:db8:1::2/64
+            node: a_eos
+          - ifname: swp1
+            ipv4: 172.19.0.4/24
+            ipv6: 2001:db8:1::4/64
+            node: n_cumulus
+        type: lan
     loopback:
       ipv4: 172.18.1.3/32
       ipv6: 2001:db8:0:3::1/64
@@ -166,4 +220,54 @@ nodes:
       ipv4: 192.168.121.103
       mac: 08-4F-A9-00-00-03
     name: j_vsrx
+  n_cumulus:
+    box: CumulusCommunity/cumulus-vx
+    device: cumulus
+    id: 4
+    interfaces:
+      - bridge: input_1
+        ifindex: 0
+        ifname: swp1
+        ipv4: 172.19.0.4/24
+        ipv6: 2001:db8:1::4/64
+        linkindex: 1
+        name: n_cumulus -> [c_nxos,a_eos,j_vsrx]
+        neighbors:
+          - ifname: Ethernet1/1
+            ipv4: 172.19.0.1/24
+            ipv6: 2001:db8:1::1/64
+            node: c_nxos
+          - ifname: Ethernet1
+            ipv4: 172.19.0.2/24
+            ipv6: 2001:db8:1::2/64
+            node: a_eos
+          - ifname: ge-0/0/0
+            ipv4: 172.19.0.3/24
+            ipv6: 2001:db8:1::3/64
+            node: j_vsrx
+        type: lan
+      - ifindex: 1
+        ifname: swp2
+        ipv4: true
+        ipv6: true
+        linkindex: 2
+        name: n_cumulus -> a_eos
+        neighbors:
+          - ifname: Ethernet3
+            ipv4: true
+            ipv6: true
+            node: a_eos
+        remote_id: 2
+        remote_ifindex: 3
+        role: core
+        type: p2p
+        unnumbered: true
+    loopback:
+      ipv4: 172.18.1.4/32
+      ipv6: 2001:db8:0:3::4/64
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08-4F-A9-00-00-04
+    name: n_cumulus
 provider: libvirt

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -1,73 +1,73 @@
 input:
-  - topology/input/unnumbered.yml
-  - package:topology-defaults.yml
+- topology/input/unnumbered.yml
+- package:topology-defaults.yml
 links:
-  - bridge: input_1
-    interfaces:
-      - ipv4: 172.19.0.1/24
-        ipv6: 2001:db8:1::1/64
-        node: c_nxos
-      - ipv4: 172.19.0.2/24
-        ipv6: 2001:db8:1::2/64
-        node: a_eos
-      - ipv4: 172.19.0.3/24
-        ipv6: 2001:db8:1::3/64
-        node: j_vsrx
-      - ipv4: 172.19.0.4/24
-        ipv6: 2001:db8:1::4/64
-        node: n_cumulus
-    linkindex: 1
-    node_count: 4
-    prefix:
-      ipv4: 172.19.0.0/24
-      ipv6: 2001:db8:1::/64
-    type: lan
-  - interfaces:
-      - ipv4: true
-        ipv6: true
-        node: a_eos
-      - ipv4: true
-        ipv6: true
-        node: c_nxos
-    left:
-      ifname: Ethernet2
-      ipv4: true
-      ipv6: true
-      node: a_eos
-    linkindex: 2
-    name: a_eos - c_nxos
-    node_count: 2
-    right:
-      ifname: Ethernet1/2
-      ipv4: true
-      ipv6: true
-      node: c_nxos
-    role: core
-    type: p2p
-    unnumbered: true
-  - interfaces:
-      - ipv4: true
-        ipv6: true
-        node: a_eos
-      - ipv4: true
-        ipv6: true
-        node: n_cumulus
-    left:
-      ifname: Ethernet3
-      ipv4: true
-      ipv6: true
-      node: a_eos
-    linkindex: 3
-    name: a_eos - c_nxos
-    node_count: 2
-    right:
-      ifname: swp2
-      ipv4: true
-      ipv6: true
-      node: n_cumulus
-    role: core
-    type: p2p
-    unnumbered: true
+- bridge: input_1
+  interfaces:
+  - ipv4: 172.19.0.1/24
+    ipv6: 2001:db8:1::1/64
+    node: c_nxos
+  - ipv4: 172.19.0.2/24
+    ipv6: 2001:db8:1::2/64
+    node: a_eos
+  - ipv4: 172.19.0.3/24
+    ipv6: 2001:db8:1::3/64
+    node: j_vsrx
+  - ipv4: 172.19.0.4/24
+    ipv6: 2001:db8:1::4/64
+    node: n_cumulus
+  linkindex: 1
+  node_count: 4
+  prefix:
+    ipv4: 172.19.0.0/24
+    ipv6: 2001:db8:1::/64
+  type: lan
+- interfaces:
+  - ipv4: true
+    ipv6: true
+    node: a_eos
+  - ipv4: true
+    ipv6: true
+    node: c_nxos
+  left:
+    ifname: Ethernet2
+    ipv4: true
+    ipv6: true
+    node: a_eos
+  linkindex: 2
+  name: a_eos - c_nxos
+  node_count: 2
+  right:
+    ifname: Ethernet1/2
+    ipv4: true
+    ipv6: true
+    node: c_nxos
+  role: core
+  type: p2p
+  unnumbered: true
+- interfaces:
+  - ipv4: true
+    ipv6: true
+    node: a_eos
+  - ipv4: true
+    ipv6: true
+    node: n_cumulus
+  left:
+    ifname: Ethernet3
+    ipv4: true
+    ipv6: true
+    node: a_eos
+  linkindex: 3
+  name: a_eos - c_nxos
+  node_count: 2
+  right:
+    ifname: swp2
+    ipv4: true
+    ipv6: true
+    node: n_cumulus
+  role: core
+  type: p2p
+  unnumbered: true
 name: input
 nodes:
   a_eos:
@@ -75,59 +75,59 @@ nodes:
     device: eos
     id: 2
     interfaces:
-      - bridge: input_1
-        ifindex: 1
-        ifname: Ethernet1
-        ipv4: 172.19.0.2/24
-        ipv6: 2001:db8:1::2/64
-        linkindex: 1
-        name: a_eos -> [c_nxos,j_vsrx,n_cumulus]
-        neighbors:
-          - ifname: Ethernet1/1
-            ipv4: 172.19.0.1/24
-            ipv6: 2001:db8:1::1/64
-            node: c_nxos
-          - ifname: ge-0/0/0
-            ipv4: 172.19.0.3/24
-            ipv6: 2001:db8:1::3/64
-            node: j_vsrx
-          - ifname: swp1
-            ipv4: 172.19.0.4/24
-            ipv6: 2001:db8:1::4/64
-            node: n_cumulus
-        type: lan
-      - ifindex: 2
-        ifname: Ethernet2
+    - bridge: input_1
+      ifindex: 1
+      ifname: Ethernet1
+      ipv4: 172.19.0.2/24
+      ipv6: 2001:db8:1::2/64
+      linkindex: 1
+      name: a_eos -> [c_nxos,j_vsrx,n_cumulus]
+      neighbors:
+      - ifname: Ethernet1/1
+        ipv4: 172.19.0.1/24
+        ipv6: 2001:db8:1::1/64
+        node: c_nxos
+      - ifname: ge-0/0/0
+        ipv4: 172.19.0.3/24
+        ipv6: 2001:db8:1::3/64
+        node: j_vsrx
+      - ifname: swp1
+        ipv4: 172.19.0.4/24
+        ipv6: 2001:db8:1::4/64
+        node: n_cumulus
+      type: lan
+    - ifindex: 2
+      ifname: Ethernet2
+      ipv4: true
+      ipv6: true
+      linkindex: 2
+      name: a_eos -> c_nxos
+      neighbors:
+      - ifname: Ethernet1/2
         ipv4: true
         ipv6: true
-        linkindex: 2
-        name: a_eos -> c_nxos
-        neighbors:
-          - ifname: Ethernet1/2
-            ipv4: true
-            ipv6: true
-            node: c_nxos
-        remote_id: 1
-        remote_ifindex: 2
-        role: core
-        type: p2p
-        unnumbered: true
-      - ifindex: 3
-        ifname: Ethernet3
+        node: c_nxos
+      remote_id: 1
+      remote_ifindex: 2
+      role: core
+      type: p2p
+      unnumbered: true
+    - ifindex: 3
+      ifname: Ethernet3
+      ipv4: true
+      ipv6: true
+      linkindex: 3
+      name: a_eos -> n_cumulus
+      neighbors:
+      - ifname: swp2
         ipv4: true
         ipv6: true
-        linkindex: 3
-        name: a_eos -> n_cumulus
-        neighbors:
-          - ifname: swp2
-            ipv4: true
-            ipv6: true
-            node: n_cumulus
-        remote_id: 4
-        remote_ifindex: 1
-        role: core
-        type: p2p
-        unnumbered: true
+        node: n_cumulus
+      remote_id: 4
+      remote_ifindex: 1
+      role: core
+      type: p2p
+      unnumbered: true
     loopback:
       ipv4: 172.18.1.2/32
       ipv6: 2001:db8:0:2::1/64
@@ -141,43 +141,43 @@ nodes:
     device: nxos
     id: 1
     interfaces:
-      - bridge: input_1
-        ifindex: 1
-        ifname: Ethernet1/1
-        ipv4: 172.19.0.1/24
-        ipv6: 2001:db8:1::1/64
-        linkindex: 1
-        name: c_nxos -> [a_eos,j_vsrx,n_cumulus]
-        neighbors:
-          - ifname: Ethernet1
-            ipv4: 172.19.0.2/24
-            ipv6: 2001:db8:1::2/64
-            node: a_eos
-          - ifname: ge-0/0/0
-            ipv4: 172.19.0.3/24
-            ipv6: 2001:db8:1::3/64
-            node: j_vsrx
-          - ifname: swp1
-            ipv4: 172.19.0.4/24
-            ipv6: 2001:db8:1::4/64
-            node: n_cumulus
-        type: lan
-      - ifindex: 2
-        ifname: Ethernet1/2
+    - bridge: input_1
+      ifindex: 1
+      ifname: Ethernet1/1
+      ipv4: 172.19.0.1/24
+      ipv6: 2001:db8:1::1/64
+      linkindex: 1
+      name: c_nxos -> [a_eos,j_vsrx,n_cumulus]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.19.0.2/24
+        ipv6: 2001:db8:1::2/64
+        node: a_eos
+      - ifname: ge-0/0/0
+        ipv4: 172.19.0.3/24
+        ipv6: 2001:db8:1::3/64
+        node: j_vsrx
+      - ifname: swp1
+        ipv4: 172.19.0.4/24
+        ipv6: 2001:db8:1::4/64
+        node: n_cumulus
+      type: lan
+    - ifindex: 2
+      ifname: Ethernet1/2
+      ipv4: true
+      ipv6: true
+      linkindex: 2
+      name: c_nxos -> a_eos
+      neighbors:
+      - ifname: Ethernet2
         ipv4: true
         ipv6: true
-        linkindex: 2
-        name: c_nxos -> a_eos
-        neighbors:
-          - ifname: Ethernet2
-            ipv4: true
-            ipv6: true
-            node: a_eos
-        remote_id: 2
-        remote_ifindex: 2
-        role: core
-        type: p2p
-        unnumbered: true
+        node: a_eos
+      remote_id: 2
+      remote_ifindex: 2
+      role: core
+      type: p2p
+      unnumbered: true
     loopback:
       ipv4: 172.18.1.1/32
       ipv6: 2001:db8:0:1::1/64
@@ -191,27 +191,27 @@ nodes:
     device: vsrx
     id: 3
     interfaces:
-      - bridge: input_1
-        ifindex: 0
-        ifname: ge-0/0/0
-        ipv4: 172.19.0.3/24
-        ipv6: 2001:db8:1::3/64
-        linkindex: 1
-        name: j_vsrx -> [c_nxos,a_eos,n_cumulus]
-        neighbors:
-          - ifname: Ethernet1/1
-            ipv4: 172.19.0.1/24
-            ipv6: 2001:db8:1::1/64
-            node: c_nxos
-          - ifname: Ethernet1
-            ipv4: 172.19.0.2/24
-            ipv6: 2001:db8:1::2/64
-            node: a_eos
-          - ifname: swp1
-            ipv4: 172.19.0.4/24
-            ipv6: 2001:db8:1::4/64
-            node: n_cumulus
-        type: lan
+    - bridge: input_1
+      ifindex: 0
+      ifname: ge-0/0/0
+      ipv4: 172.19.0.3/24
+      ipv6: 2001:db8:1::3/64
+      linkindex: 1
+      name: j_vsrx -> [c_nxos,a_eos,n_cumulus]
+      neighbors:
+      - ifname: Ethernet1/1
+        ipv4: 172.19.0.1/24
+        ipv6: 2001:db8:1::1/64
+        node: c_nxos
+      - ifname: Ethernet1
+        ipv4: 172.19.0.2/24
+        ipv6: 2001:db8:1::2/64
+        node: a_eos
+      - ifname: swp1
+        ipv4: 172.19.0.4/24
+        ipv6: 2001:db8:1::4/64
+        node: n_cumulus
+      type: lan
     loopback:
       ipv4: 172.18.1.3/32
       ipv6: 2001:db8:0:3::1/64
@@ -225,43 +225,43 @@ nodes:
     device: cumulus
     id: 4
     interfaces:
-      - bridge: input_1
-        ifindex: 0
-        ifname: swp1
-        ipv4: 172.19.0.4/24
-        ipv6: 2001:db8:1::4/64
-        linkindex: 1
-        name: n_cumulus -> [c_nxos,a_eos,j_vsrx]
-        neighbors:
-          - ifname: Ethernet1/1
-            ipv4: 172.19.0.1/24
-            ipv6: 2001:db8:1::1/64
-            node: c_nxos
-          - ifname: Ethernet1
-            ipv4: 172.19.0.2/24
-            ipv6: 2001:db8:1::2/64
-            node: a_eos
-          - ifname: ge-0/0/0
-            ipv4: 172.19.0.3/24
-            ipv6: 2001:db8:1::3/64
-            node: j_vsrx
-        type: lan
-      - ifindex: 1
-        ifname: swp2
+    - bridge: input_1
+      ifindex: 0
+      ifname: swp1
+      ipv4: 172.19.0.4/24
+      ipv6: 2001:db8:1::4/64
+      linkindex: 1
+      name: n_cumulus -> [c_nxos,a_eos,j_vsrx]
+      neighbors:
+      - ifname: Ethernet1/1
+        ipv4: 172.19.0.1/24
+        ipv6: 2001:db8:1::1/64
+        node: c_nxos
+      - ifname: Ethernet1
+        ipv4: 172.19.0.2/24
+        ipv6: 2001:db8:1::2/64
+        node: a_eos
+      - ifname: ge-0/0/0
+        ipv4: 172.19.0.3/24
+        ipv6: 2001:db8:1::3/64
+        node: j_vsrx
+      type: lan
+    - ifindex: 1
+      ifname: swp2
+      ipv4: true
+      ipv6: true
+      linkindex: 2
+      name: n_cumulus -> a_eos
+      neighbors:
+      - ifname: Ethernet3
         ipv4: true
         ipv6: true
-        linkindex: 2
-        name: n_cumulus -> a_eos
-        neighbors:
-          - ifname: Ethernet3
-            ipv4: true
-            ipv6: true
-            node: a_eos
-        remote_id: 2
-        remote_ifindex: 3
-        role: core
-        type: p2p
-        unnumbered: true
+        node: a_eos
+      remote_id: 2
+      remote_ifindex: 3
+      role: core
+      type: p2p
+      unnumbered: true
     loopback:
       ipv4: 172.18.1.4/32
       ipv6: 2001:db8:0:3::4/64

--- a/tests/topology/input/unnumbered.yml
+++ b/tests/topology/input/unnumbered.yml
@@ -15,12 +15,19 @@ nodes:
   device: eos
 - name: j_vsrx
   device: vsrx
+- name: n_cumulus
+  device: cumulus
 
 links:
 - c_nxos:
   a_eos:
   j_vsrx:
+  n_cumulus:
 
 - c_nxos:
   a_eos:
+  role: core
+
+- a_eos:
+  n_cumulus:
   role: core


### PR DESCRIPTION
Platforms: Add support for IP unnumbered interfaces on Cumulus

- Mod `initial/cumulus.j2` to set unnumbered interfaces to have loopback IP address
  - Reference: https://support.cumulusnetworks.com/hc/en-us/articles/202796476-RETIRED-OSPF-Unnumbered-Sample-Configurations
- Mod `topology-defaults.yml` to allow ip unnumbered and ospf unnumbered
- Add cumulus box to `tests` @ipspace please verify these two changes, as I can't test since I don't have all the images mentioned