### PR TITLE
Platforms: Cumulus eBGP unnumbered support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ sftp-config.json
 dist/
 .eggs/
 *.egg-info
+.vscode/launch.json

--- a/netsim/ansible/templates/bgp/cumulus.j2
+++ b/netsim/ansible/templates/bgp/cumulus.j2
@@ -8,15 +8,27 @@ router bgp {{ bgp.as }}
   bgp default show-hostname
   bgp default show-nexthop-hostname
 !
-{% for af in ['ipv4','ipv6'] %}
-{%   for n in bgp.neighbors if n[af] is defined %}
+{% for n in bgp.neighbors %}
+{%   if n.unnumbered is defined and n.unnumbered is sameas true %}
+{%     if loop.first %}
+  neighbor external peer-group
+  neighbor external remote-as external
+{%     endif %}
+  neighbor {{ n.interface }} interface peer-group external
+  neighbor {{ n.interface }} description {{ n.name }}
+{%   else %}
+{%     for af in ['ipv4','ipv6'] %}
+{%       if n[af] is defined %}
   neighbor {{ n[af] }} remote-as {{ n.as }}
   neighbor {{ n[af] }} description {{ n.name }}
+{%       endif %}
+{%     endfor %}
 {%     if n.type == 'ibgp' %}
   neighbor {{ n[af] }} update-source lo
 {%     endif %}
-!
-{%   endfor %}
+  !
+{%   endif %}
+  !
 {% endfor %}
 {% for af in ['ipv4','ipv6'] if bgp[af] is defined %}
  address-family {{ af }} unicast
@@ -33,8 +45,13 @@ router bgp {{ bgp.as }}
   network {{ pfx|ipaddr('0') }}
 {%   endfor %}
 !
-{%   for n in bgp.neighbors if n[af] is defined %}
+{# {%   for n in bgp.neighbors if n[af] is defined %} #}
+{%   for n in bgp.neighbors %}
+{%     if n.unnumbered is defined and n.unnumbered is sameas true %}
+  neighbor {{ n.interface }} activate
+{%     else %}
   neighbor {{ n[af] }} activate
+{%     endif %}
 {%     if n.type == 'ibgp' %}
 {%       if bgp.next_hop_self is defined and bgp.next_hop_self %}
   neighbor {{ n[af] }} next-hop-self
@@ -47,7 +64,11 @@ router bgp {{ bgp.as }}
 {%       endif %}
 {%     else %}
 {%       if bgp.community.ebgp|default([]) %}
+{%         if n.unnumbered is defined and n.unnumbered is sameas true %}
+  neighbor {{ n.interface }} send-community {{ community(bgp.community.ebgp) }}
+{%         else %}
   neighbor {{ n[af] }} send-community {{ community(bgp.community.ebgp) }}
+{%         endif %}
 {%       endif %}
 {%     endif %}
 !

--- a/netsim/ansible/templates/bgp/cumulus.j2
+++ b/netsim/ansible/templates/bgp/cumulus.j2
@@ -14,8 +14,8 @@ router bgp {{ bgp.as }}
   neighbor external peer-group
   neighbor external remote-as external
 {%     endif %}
-  neighbor {{ n.interface }} interface peer-group external
-  neighbor {{ n.interface }} description {{ n.name }}
+  neighbor {{ n.local_if }} interface peer-group external
+  neighbor {{ n.local_if }} description {{ n.name }}
 {%   else %}
 {%     for af in ['ipv4','ipv6'] %}
 {%       if n[af] is defined %}
@@ -48,7 +48,7 @@ router bgp {{ bgp.as }}
 {# {%   for n in bgp.neighbors if n[af] is defined %} #}
 {%   for n in bgp.neighbors %}
 {%     if n.unnumbered is defined and n.unnumbered is sameas true %}
-  neighbor {{ n.interface }} activate
+  neighbor {{ n.local_if }} activate
 {%     else %}
   neighbor {{ n[af] }} activate
 {%     endif %}
@@ -65,7 +65,7 @@ router bgp {{ bgp.as }}
 {%     else %}
 {%       if bgp.community.ebgp|default([]) %}
 {%         if n.unnumbered is defined and n.unnumbered is sameas true %}
-  neighbor {{ n.interface }} send-community {{ community(bgp.community.ebgp) }}
+  neighbor {{ n.local_if }} send-community {{ community(bgp.community.ebgp) }}
 {%         else %}
   neighbor {{ n[af] }} send-community {{ community(bgp.community.ebgp) }}
 {%         endif %}

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -55,7 +55,7 @@ def bgp_neighbor(n: Box, intf: Box, ctype: str, extra_data: typing.Optional[dict
   ngb["type"] = ctype
   for af in ["ipv4", "ipv6"]:
     if af in intf:
-      if ngb.unnumbered == True:
+      if "unnumbered" in ngb and ngb.unnumbered == True:
         ngb[af] = True
       else:
         ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -55,9 +55,8 @@ def bgp_neighbor(n: Box, intf: Box, ctype: str, extra_data: typing.Optional[dict
   ngb["type"] = ctype
   for af in ["ipv4", "ipv6"]:
     if af in intf:
-      if extra_data.unnumbered == True:
+      if ngb.unnumbered == True:
         ngb[af] = True
-        ngb["interface"] = extra_data.local_if
       else:
         ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
   return ngb

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -11,141 +11,136 @@ from . import _Module
 from .. import common
 from ..augment.links import IFATTR
 
+
 def check_bgp_parameters(node: Box) -> None:
   if not "bgp" in node:  # pragma: no cover (should have been tested and reported by the caller)
     return
-  if not "as" in node.bgp or not isinstance(node.bgp.get('as',{}),int):
+  if not "as" in node.bgp or not isinstance(node.bgp.get("as", {}), int):
     common.error("Node %s has BGP enabled but no AS number specified" % node.name)
 
   if "community" in node.bgp:
     bgp_comm = node.bgp.community
-    if isinstance(bgp_comm,str):
-      node.bgp.community = { 'ibgp' : [ bgp_comm ], 'ebgp': [ bgp_comm ]}
-    elif isinstance(bgp_comm,list):
-      node.bgp.community = { 'ibgp' : bgp_comm, 'ebgp': bgp_comm }
-    elif not(isinstance(bgp_comm,dict)):
-      common.error("bgp.community attribute in node %s should be a string, a list, or a dictionary (%s)" % (node.name,str(bgp_comm)))
+    if isinstance(bgp_comm, str):
+      node.bgp.community = {"ibgp": [bgp_comm], "ebgp": [bgp_comm]}
+    elif isinstance(bgp_comm, list):
+      node.bgp.community = {"ibgp": bgp_comm, "ebgp": bgp_comm}
+    elif not (isinstance(bgp_comm, dict)):
+      common.error("bgp.community attribute in node %s should be a string, a list, or a dictionary (%s)" % (node.name, str(bgp_comm)))
       return
 
     for k in node.bgp.community.keys():
-      if not k in ['ibgp','ebgp']:
-        common.error("Invalid BGP community setting in node %s: %s" % (node.name,k))
-      if isinstance(node.bgp.community[k],str):
-        node.bgp.community[k] = [ node.bgp.community[k] ]
+      if not k in ["ibgp", "ebgp"]:
+        common.error("Invalid BGP community setting in node %s: %s" % (node.name, k))
+      if isinstance(node.bgp.community[k], str):
+        node.bgp.community[k] = [node.bgp.community[k]]
       for v in node.bgp.community[k]:
-        if not v in ['standard','extended']:
-          common.error("Invalid BGP community propagation setting for %s sessions in node %s: %s" % (k,node.name,v))
+        if not v in ["standard", "extended"]:
+          common.error("Invalid BGP community propagation setting for %s sessions in node %s: %s" % (k, node.name, v))
+
 
 def find_bgp_rr(bgp_as: int, topology: Box) -> typing.List[Box]:
   rrlist = []
-  for name,n in topology.nodes.items():
+  for name, n in topology.nodes.items():
     if not "bgp" in n:
       continue
-    if n.bgp["as"] == bgp_as and n.bgp.get("rr",None):
+    if n.bgp["as"] == bgp_as and n.bgp.get("rr", None):
       rrlist.append(n)
   return rrlist
 
+
 def bgp_neighbor(n: Box, intf: Box, ctype: str, extra_data: typing.Optional[dict] = None) -> Box:
-  ngb = Box(extra_data or {},default_box=True,box_dots=True)
+  ngb = Box(extra_data or {}, default_box=True, box_dots=True)
   ngb.name = n.name
   ngb["as"] = n.bgp.get("as")
   ngb["type"] = ctype
-  for af in ['ipv4','ipv6']:
+  for af in ["ipv4", "ipv6"]:
     if af in intf:
-      ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
+      if extra_data.unnumbered == True:
+        ngb[af] = True
+        ngb["interface"] = extra_data.local_if
+      else:
+        ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
   return ngb
+
 
 def get_neighbor_rr(n: Box) -> typing.Optional[typing.Dict]:
   if "rr" in n.get("bgp"):
-    return { "rr" : n.bgp.rr }
+    return {"rr": n.bgp.rr}
 
   return {}
 
+
 class BGP(_Module):
 
-  '''
+  """
   process_as_list:
     If the global BGP parameters have as_list attribute, set node AS numbers and node
     RR flags accordingly
-  '''
+  """
+
   def process_as_list(self, topology: Box) -> None:
-    if not 'bgp' in topology:                            # Do we have global BGP settings?
+    if not "bgp" in topology:  # Do we have global BGP settings?
       return
 
-    if not 'as_list' in topology.bgp:                    # Do we have global AS list?
+    if not "as_list" in topology.bgp:  # Do we have global AS list?
       return
 
-    if not isinstance(topology.bgp.as_list,dict):
-      common.error(
-        "bgp.as_list should be a dictionary of AS parameters",
-        common.IncorrectValue)
+    if not isinstance(topology.bgp.as_list, dict):
+      common.error("bgp.as_list should be a dictionary of AS parameters", common.IncorrectValue)
       return
 
-    node_data = Box({},default_box=True,box_dots=True)
-    for asn,data in topology.bgp.as_list.items():
-      if not isinstance(data,Box):
-        common.error(
-          "Invalid value in bgp.as_list for ASN %s: " % asn + \
-          "\n... Each ASN in a BGP as_list must be a dictionary with (at least) members key:"+
-          "\n... Found: %s" % data,
-          common.IncorrectValue)
+    node_data = Box({}, default_box=True, box_dots=True)
+    for asn, data in topology.bgp.as_list.items():
+      if not isinstance(data, Box):
+        common.error("Invalid value in bgp.as_list for ASN %s: " % asn + "\n... Each ASN in a BGP as_list must be a dictionary with (at least) members key:" + "\n... Found: %s" % data, common.IncorrectValue)
         continue
 
-      if not 'members' in data:
-        common.error(
-          "BGP as_list for ASN %s does not have a member attribute" % asn,
-          common.IncorrectValue)
+      if not "members" in data:
+        common.error("BGP as_list for ASN %s does not have a member attribute" % asn, common.IncorrectValue)
         continue
 
-      common.must_be_list(data,'members',f'bgp.as_list.{asn}')
+      common.must_be_list(data, "members", f"bgp.as_list.{asn}")
       for n in data.members:
         if not n in topology.nodes:
-          common.error(
-            "Invalid node name %s in member list of BGP AS %s" % (n,asn),
-            common.IncorrectValue)
+          common.error("Invalid node name %s in member list of BGP AS %s" % (n, asn), common.IncorrectValue)
           continue
         node_data[n]["as"] = asn
 
-      for n in data.get('rr',{}):
+      for n in data.get("rr", {}):
         if not n in topology.nodes:
-          common.error(
-            "Invalid node name %s in route reflector list of BGP AS %s" % (n,asn),
-            common.IncorrectValue)
+          common.error("Invalid node name %s in route reflector list of BGP AS %s" % (n, asn), common.IncorrectValue)
           continue
         if node_data[n]["as"] != asn:
-          common.error(
-            "Node %s is specified as route reflector in AS %s but is not in member list" % (n,asn),
-            common.IncorrectValue)
+          common.error("Node %s is specified as route reflector in AS %s but is not in member list" % (n, asn), common.IncorrectValue)
           continue
         node_data[n].rr = True
 
-    for name,node in topology.nodes.items():
+    for name, node in topology.nodes.items():
       if name in node_data:
-        node_as = node.bgp.get("as",None)
+        node_as = node.bgp.get("as", None)
         if node_as and node_as != node_data[name]["as"]:
-          common.error(
-            "Node %s has AS %s but is also in member list of AS %s" % (node.name,node_as,node_data[node.name]["as"]),
-            common.IncorrectValue)
+          common.error("Node %s has AS %s but is also in member list of AS %s" % (node.name, node_as, node_data[node.name]["as"]), common.IncorrectValue)
           continue
 
         node.bgp = node_data[name] + node.bgp
 
-  '''
+  """
   bgp_build_group: create automatic groups based on BGP AS numbers
-  '''
-  def build_bgp_groups(self, topology: Box) -> None:
-    for gname,gdata in topology.groups.items():
-      if re.match('as\\d+$',gname):
-        if gdata.get('members',None):
-          common.error('BGP AS groups should not have static members %s' % gname)
+  """
 
-    for name,node in topology.nodes.items():
-      if 'bgp' in node and 'as' in node.bgp:
+  def build_bgp_groups(self, topology: Box) -> None:
+    for gname, gdata in topology.groups.items():
+      if re.match("as\\d+$", gname):
+        if gdata.get("members", None):
+          common.error("BGP AS groups should not have static members %s" % gname)
+
+    for name, node in topology.nodes.items():
+      if "bgp" in node and "as" in node.bgp:
         grpname = "as%s" % node.bgp["as"]
         if not grpname in topology.groups:
-          topology.groups[grpname] = { 'members': [] }
+          topology.groups[grpname] = {"members": []}
 
-        if not 'members' in topology.groups[grpname]:   # pragma: no cover (members list is created in group processing)
+        if not "members" in topology.groups[grpname]:  # pragma: no cover (members list is created in group processing)
           topology.groups[grpname].members = []
 
         topology.groups[grpname].members.append(name)
@@ -156,6 +151,7 @@ class BGP(_Module):
   * process AS list
   * create automatic BGP groups
   """
+
   def module_pre_default(self, topology: Box) -> None:
     self.process_as_list(topology)
     self.build_bgp_groups(topology)
@@ -165,8 +161,9 @@ class BGP(_Module):
   global bgp.rr attribute. Also, delete the global bgp.rr attribute so it's not propagated
   down to nodes
   """
+
   def node_pre_transform(self, node: Box, topology: Box) -> None:
-    if "rr_list" in topology.get("bgp",{}):
+    if "rr_list" in topology.get("bgp", {}):
       if node.name in topology.bgp.rr_list:
         node.bgp.rr = True
 
@@ -176,13 +173,14 @@ class BGP(_Module):
   If the nodes belong to at least two autonomous systems, and the ebgp_role
   variable is set, set the link role to ebgp_role
   """
+
   def link_pre_transform(self, link: Box, topology: Box) -> None:
-    ebgp_role = topology.bgp.get("ebgp_role",None) or topology.defaults.bgp.get("ebgp_role",None)
+    ebgp_role = topology.bgp.get("ebgp_role", None) or topology.defaults.bgp.get("ebgp_role", None)
     if not ebgp_role:
       return
 
     as_set = {}
-    for ifdata in link.get(IFATTR,[]):
+    for ifdata in link.get(IFATTR, []):
       n = ifdata.node
       if "bgp" in topology.nodes[n]:
         node_as = topology.nodes[n].bgp.get("as")
@@ -200,30 +198,31 @@ class BGP(_Module):
   * EBGP sessions are established whenever two nodes on the same link have different AS
   * Links matching 'advertise_roles' get 'advertise' attribute set
   """
+
   def build_bgp_sessions(self, node: Box, topology: Box) -> None:
-    rrlist = find_bgp_rr(node.bgp.get("as"),topology)
+    rrlist = find_bgp_rr(node.bgp.get("as"), topology)
     node.bgp.neighbors = []
 
     # If we don't have route reflectors, or if the current node is a route
     # reflector, we need BGP sessions to all other nodes in the same AS
-    if not(rrlist) or node.bgp.get("rr",None):
-      for name,n in topology.nodes.items():
+    if not (rrlist) or node.bgp.get("rr", None):
+      for name, n in topology.nodes.items():
         if "bgp" in n:
           if n.bgp.get("as") == node.bgp.get("as") and n.name != node.name:
-            node.bgp.neighbors.append(bgp_neighbor(n,n.loopback,'ibgp',get_neighbor_rr(n)))
+            node.bgp.neighbors.append(bgp_neighbor(n, n.loopback, "ibgp", get_neighbor_rr(n)))
     #
     # The node is not a route reflector, and we have a non-empty RR list
     # We need BGP sessions with the route reflectors
     else:
       for n in rrlist:
         if n.name != node.name:
-          node.bgp.neighbors.append(bgp_neighbor(n,n.loopback,'ibgp',get_neighbor_rr(n)))
+          node.bgp.neighbors.append(bgp_neighbor(n, n.loopback, "ibgp", get_neighbor_rr(n)))
 
     #
     # EBGP sessions - iterate over all links, find adjacent nodes
     # in different AS numbers, and create BGP neighbors
-    for l in node.get("interfaces",[]):
-      for ngb_ifdata in l.get("neighbors",[]):
+    for l in node.get("interfaces", []):
+      for ngb_ifdata in l.get("neighbors", []):
         ngb_name = ngb_ifdata.node
         neighbor = topology.nodes[ngb_name]
         if not "bgp" in neighbor:
@@ -233,37 +232,39 @@ class BGP(_Module):
           extra_data.ifindex = l.ifindex
           if "unnumbered" in l:
             extra_data.unnumbered = True
-          node.bgp.neighbors.append(bgp_neighbor(neighbor,ngb_ifdata,'ebgp',extra_data))
+            extra_data.local_if = l.ifname
+          node.bgp.neighbors.append(bgp_neighbor(neighbor, ngb_ifdata, "ebgp", extra_data))
 
     # Calculate BGP address families
     #
-    for af in ['ipv4','ipv6']:
+    for af in ["ipv4", "ipv6"]:
       for n in node.bgp.neighbors:
         if af in n:
           node.bgp[af] = True
           break
 
-  '''
+  """
   bgp_set_advertise: set bgp.advertise flag on stub links
-  '''
+  """
+
   def bgp_set_advertise(self, node: Box, topology: Box) -> None:
-    stub_roles = topology.defaults.bgp.get("advertise_roles",None)
-    if 'advertise_roles' in topology.bgp:
-      stub_roles = topology.bgp.get("advertise_roles",None)
+    stub_roles = topology.defaults.bgp.get("advertise_roles", None)
+    if "advertise_roles" in topology.bgp:
+      stub_roles = topology.bgp.get("advertise_roles", None)
     if stub_roles:
-      for l in node.get("interfaces",[]):
+      for l in node.get("interfaces", []):
         if "bgp" in l:
           if "advertise" in l.bgp:
             continue
-        if l.get("type",None) in stub_roles or l.get("role",None) in stub_roles:
-          if not 'bgp' in l:
+        if l.get("type", None) in stub_roles or l.get("role", None) in stub_roles:
+          if not "bgp" in l:
             l.bgp = {}
           l.bgp.advertise = True
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
-    if not "bgp" in node:   # pragma: no cover (this should have been caught in check_bgp_parameters)
-      common.fatal(f"Internal error: node {node.name} has BGP module enabled but no BGP parameters","bgp")
+    if not "bgp" in node:  # pragma: no cover (this should have been caught in check_bgp_parameters)
+      common.fatal(f"Internal error: node {node.name} has BGP module enabled but no BGP parameters", "bgp")
       return
     check_bgp_parameters(node)
-    self.build_bgp_sessions(node,topology)
-    self.bgp_set_advertise(node,topology)
+    self.build_bgp_sessions(node, topology)
+    self.bgp_set_advertise(node, topology)

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -1,0 +1,247 @@
+bgp:
+  advertise_loopback: true
+  as_list:
+    65000:
+      members:
+      - r1
+    65100:
+      members:
+      - r2
+    65200:
+      members:
+      - r3
+  community:
+    ebgp:
+    - standard
+    ibgp:
+    - standard
+    - extended
+  next_hop_self: true
+groups:
+  as65000:
+    members:
+    - r1
+  as65100:
+    members:
+    - r2
+  as65200:
+    members:
+    - r3
+input:
+- topology/input/bgp-unnumbered.yml
+- package:topology-defaults.yml
+links:
+- interfaces:
+  - ipv4: true
+    ipv6: true
+    node: r1
+  - ipv4: true
+    ipv6: true
+    node: r2
+  left:
+    ifname: swp1
+    ipv4: true
+    ipv6: true
+    node: r1
+  linkindex: 1
+  name: r1 - r2
+  node_count: 2
+  right:
+    ifname: swp1
+    ipv4: true
+    ipv6: true
+    node: r2
+  role: external
+  type: p2p
+  unnumbered: true
+- interfaces:
+  - ipv4: 10.10.10.1/24
+    node: r2
+  - ipv4: 10.10.10.2/24
+    node: r3
+  left:
+    ifname: swp2
+    ipv4: 10.10.10.1/24
+    node: r2
+  linkindex: 2
+  name: r2 - r3
+  node_count: 2
+  prefix: 10.10.10.0/24
+  right:
+    ifname: swp1
+    ipv4: 10.10.10.2/24
+    node: r3
+  role: external
+  type: p2p
+module:
+- bgp
+name: input
+nodes:
+  r1:
+    bgp:
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      ipv6: true
+      neighbors:
+      - as: 65100
+        ifindex: 1
+        ipv4: true
+        ipv6: true
+        local_if: swp1
+        name: r2
+        type: ebgp
+        unnumbered: true
+      next_hop_self: true
+    box: CumulusCommunity/cumulus-vx
+    device: cumulus
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: swp1
+      ipv4: true
+      ipv6: true
+      linkindex: 1
+      name: r1 -> r2
+      neighbors:
+      - ifname: swp1
+        ipv4: true
+        ipv6: true
+        node: r2
+      remote_id: 2
+      remote_ifindex: 1
+      role: external
+      type: p2p
+      unnumbered: true
+    loopback:
+      ipv4: 10.0.0.1/32
+      ipv6: 2001:db8:cafe:1::1/64
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08-4F-A9-00-00-01
+    module:
+    - bgp
+    name: r1
+  r2:
+    bgp:
+      advertise_loopback: true
+      as: 65100
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      ipv6: true
+      neighbors:
+      - as: 65000
+        ifindex: 1
+        ipv4: true
+        ipv6: true
+        local_if: swp1
+        name: r1
+        type: ebgp
+        unnumbered: true
+      - as: 65200
+        ifindex: 2
+        ipv4: 10.10.10.2
+        name: r3
+        type: ebgp
+      next_hop_self: true
+    box: CumulusCommunity/cumulus-vx
+    device: cumulus
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: swp1
+      ipv4: true
+      ipv6: true
+      linkindex: 1
+      name: r2 -> r1
+      neighbors:
+      - ifname: swp1
+        ipv4: true
+        ipv6: true
+        node: r1
+      remote_id: 1
+      remote_ifindex: 1
+      role: external
+      type: p2p
+      unnumbered: true
+    - ifindex: 2
+      ifname: swp2
+      ipv4: 10.10.10.1/24
+      linkindex: 2
+      name: r2 -> r3
+      neighbors:
+      - ifname: swp1
+        ipv4: 10.10.10.2/24
+        node: r3
+      remote_id: 3
+      remote_ifindex: 1
+      role: external
+      type: p2p
+    loopback:
+      ipv4: 10.0.0.2/32
+      ipv6: 2001:db8:cafe:2::1/64
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - bgp
+    name: r2
+  r3:
+    bgp:
+      advertise_loopback: true
+      as: 65200
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      neighbors:
+      - as: 65100
+        ifindex: 1
+        ipv4: 10.10.10.1
+        name: r2
+        type: ebgp
+      next_hop_self: true
+    box: CumulusCommunity/cumulus-vx
+    device: cumulus
+    id: 3
+    interfaces:
+    - ifindex: 1
+      ifname: swp1
+      ipv4: 10.10.10.2/24
+      linkindex: 2
+      name: r3 -> r2
+      neighbors:
+      - ifname: swp2
+        ipv4: 10.10.10.1/24
+        node: r2
+      remote_id: 2
+      remote_ifindex: 2
+      role: external
+      type: p2p
+    loopback:
+      ipv4: 10.0.0.3/32
+      ipv6: 2001:db8:cafe:3::1/64
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    module:
+    - bgp
+    name: r3
+provider: libvirt

--- a/tests/topology/input/bgp-unnumbered.yml
+++ b/tests/topology/input/bgp-unnumbered.yml
@@ -1,0 +1,32 @@
+#
+# Sample multi-vendor configuration that tests most features supported by BGP configuration module
+#
+# Used in manual testing (feel free to write an automated test script ;)
+#
+module: [bgp]
+
+addressing:
+  p2p:
+    unnumbered: true
+  loopback:
+    ipv6: 2001:db8:cafe::/48
+
+defaults:
+  device: cumulus
+
+bgp:
+  as_list:
+    65000:
+      members: [r1]
+    65100:
+      members: [r2]
+    65200:
+      members: [r3]
+
+nodes: [r1, r2, r3]
+
+links:
+  - r1-r2
+  - r2:
+    r3:
+    prefix: 10.10.10.0/24


### PR DESCRIPTION
Platforms: Add initial support for ebgp unnumbered on Cumulus

* mod `netsim/ansible/templates/bgp/cumulus.j2` to change logic:
  * if bgp neighbor is unnumbered, don't bother with BGP AFs since unnumbered can't distinguish them
  * else add per-AF peer info 
  
* mod `netsim/modules/bgp.py to support ebgp unnumbered:
  * Sorry about the python formatting changes! See issue filed so I don't ever do this again, or I can resubmit
  * Lines 58-62: Set unnumbered interface ip to `True` and capture local interface name
  * Line 235: pass local interface to function via `extra_data`