### PR TITLE
Use router_id for sros and srlinux

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.cli.j2
+++ b/netsim/ansible/templates/bgp/srlinux.cli.j2
@@ -15,7 +15,7 @@
 
 /network-instance default protocols bgp
 autonomous-system {{ bgp.as }}
-router-id {{ loopback['ipv4']|ipaddr('address') }}
+router-id {{ bgp.router_id }}
 ipv4-unicast admin-state disable
 ebgp-default-policy export-reject-all false
 ebgp-default-policy import-reject-all false
@@ -43,7 +43,7 @@ send-community large {{ 'true' if 'large' in list else 'false' }}
 #}
 {% if g=='ibgp' and bgp.rr|default(0)|bool %}
  route-reflector {
-  cluster-id {{ loopback['ipv4']|ipaddr('address') }}
+  cluster-id {{ bgp.router_id }}
   client true
  }
  next-hop-self false

--- a/netsim/ansible/templates/bgp/srlinux.j2
+++ b/netsim/ansible/templates/bgp/srlinux.j2
@@ -14,7 +14,7 @@ updates:
 - path: network-instance[name=default]/protocols/bgp
   val:
    autonomous-system: {{ bgp.as }}
-   router-id: {{ loopback['ipv4']|ipaddr('address') }}
+   router-id: {{ bgp.router_id }}
    ipv4-unicast:
     admin-state: disable
    ebgp-default-policy:
@@ -53,7 +53,7 @@ updates:
 #}
 {%   if ibgp_rr %}
      route-reflector:
-      cluster-id: {{ loopback['ipv4']|ipaddr('address') }}
+      cluster-id: {{ bgp.router_id }}
       client: True
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/bgp/sros.gnmi.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.j2
@@ -2,7 +2,7 @@
 updates:
 - path: configure/router[router-name=Base]
   val:
-   router-id: "{{ loopback['ipv4']|ipaddr('address') }}"
+   router-id: "{{ bgp.router_id }}"
    autonomous-system: {{ bgp.as }}
    bgp:
     ebgp-default-reject-policy:
@@ -44,7 +44,7 @@ updates:
       local-address: "{{ loopback[ c[5:] ]|ipaddr('address') }}"
 {%    if bgp.rr|default('')|bool %}
       cluster:
-        cluster-id: "{{ loopback['ipv4']|ipaddr('address') }}"
+        cluster-id: "{{ bgp.router_id }}"
 {%    elif bgp.next_hop_self|default(false) %}
       next-hop-self: True
 {%    endif %}

--- a/netsim/ansible/templates/bgp/sros.md-cli.j2
+++ b/netsim/ansible/templates/bgp/sros.md-cli.j2
@@ -49,7 +49,7 @@ exit
 / configure router bgp ebgp-default-reject-policy import false
 / configure router bgp ebgp-default-reject-policy export false
 / configure router bgp min-route-advertisement 1 connect-retry 5
-/ configure router router-id {{ loopback['ipv4']|ipaddr('address') }}
+/ configure router router-id {{ bgp.router_id }}
 
 {#
     Configure IPv4 and IPv6 BGP neighbors

--- a/netsim/ansible/templates/bgp/sros.openconfig.j2
+++ b/netsim/ansible/templates/bgp/sros.openconfig.j2
@@ -23,6 +23,7 @@ updates:
           maximum-paths: 64
        config:
         as: {{ bgp.as }}
+        router-id: {{ bgp.router_id }}
       peer-groups:
        peer-group:
 {%     for c in ['ebgp','ibgp'] %}

--- a/netsim/ansible/templates/bgp/sros.openconfig.j2
+++ b/netsim/ansible/templates/bgp/sros.openconfig.j2
@@ -39,7 +39,7 @@ updates:
 {%       if bgp.rr|default(0)|bool and c=='ibgp' %}
          route-reflector:
           config:
-           route-reflector-cluster-id: "{{ loopback.ipv4|ipaddr('address') }}"
+           route-reflector-cluster-id: "{{ bgp.router_id }}"
 {%       endif %}
 {%     endfor %}
 

--- a/netsim/ansible/templates/ospf/srlinux.j2
+++ b/netsim/ansible/templates/ospf/srlinux.j2
@@ -2,7 +2,7 @@
 updates:
 - path: network-instance[name=default]
   val:
-   router-id: {{ loopback['ipv4']|ipaddr('address') }}
+   router-id: {{ ospf.router_id }}
    protocols:
     ospf:
      instance:

--- a/netsim/ansible/templates/ospf/sros.gnmi.j2
+++ b/netsim/ansible/templates/ospf/sros.gnmi.j2
@@ -7,7 +7,7 @@
 updates:
 - path: configure/router[router-name=Base]
   val:
-   router-id: "{{ loopback['ipv4']|ipaddr('address') }}"
+   router-id: "{{ ospf.router_id }}"
    ospf:
    - ospf-instance: {{ pid }}
 {% if ospf.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/ospf/sros.md-cli.j2
+++ b/netsim/ansible/templates/ospf/sros.md-cli.j2
@@ -1,6 +1,6 @@
 {% set pid = ospf.process|default(0) %}
 {% set area = ospf.area|default("0.0.0.0") %}
-/configure router router-id {{ loopback['ipv4']|ipaddr('address') }}
+/configure router router-id {{ ospf.router_id }}
 /configure router ospf {{ pid }}
 
 version ospf-v2


### PR DESCRIPTION
Implements https://github.com/ipspace/netsim-tools/issues/148

I noticed the other templates check for a valid ipv4 address, assuming that is unnecessary

Note that IS-IS also needs a router-id (per protocol instance)