### PR TITLE
Add srv6 module (with initial support on sros)

### DIFF
--- a/docs/module/srv6.md
+++ b/docs/module/srv6.md
@@ -1,0 +1,57 @@
+# Segment Routing over IPv6 (srv6) Configuration Module
+
+This configuration module configures SRv6 over IS-IS and (optionally) BGP on Nokia SR OS.
+
+Supported SRv6 features:
+
+* End SIDs (nodes) and End-x SIDs (links), all statically allocated
+* IS-IS routing protocol with SRv6 TLVs
+* Dynamic BGP Service SIDs
+
+The module currently depends on IS-IS module and will trigger a configuration error if the **isis** module is not enabled in the network topology.
+
+## Parameters
+
+* Locator: an IPv6 address range to allocate to SRv6 nodes; each node is assigned a unique /64 prefix from this range
+
+## Example
+
+We want to create a four-router SRv6 network.
+
+All devices run IS-IS and SRv6:
+```
+module: [ isis, srv6 ]
+```
+
+We want to use unnumbered P2P interfaces and dual-stack deployment with IPv6 configured on loopback addresses:
+
+```
+addressing:
+  p2p:
+    unnumbered: true
+  loopback:
+    ipv6: 2001:db8:cafe::/48
+
+srv6.locator: 2001:db8:aaaa::/48  # Must not overlap with interfaces
+```
+
+```
+provider: clab
+defaults.device: sros # Type must support FP4 chipset
+
+nodes:
+  e1:
+  e2:
+  c1:
+  c2:
+```
+
+The devices are connected into a square topology:
+
+```
+links:
+- e1-c1
+- e1-c2
+- e2-c1
+- e2-c2
+```

--- a/netsim/ansible/tasks/deploy-config/sros.yml
+++ b/netsim/ansible/tasks/deploy-config/sros.yml
@@ -55,7 +55,7 @@
 - block:
   - block:
     - name: Enable Open Config YAML modules (retry to give Containerlab a chance to finish configuration)
-      when: enable_open_config is not defined and 'ixr-ec' != type
+      when: enable_open_config is not defined and 'ixr-ec' != clab.type
       tags: [ initial ]
       nokia.grpc.gnmi_config:
         prefix: configure

--- a/netsim/ansible/templates/bgp/sros.gnmi.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.j2
@@ -13,7 +13,7 @@ updates:
      ebgp: {{ 16 if 'ixr' in clab.type else 64 }}
     min-route-advertisement: 1 # Be aggressive about sending updates
     connect-retry: 5           # Retry frequently, suitable in DC context
-    client-reflect: {{ 'True' if bgp.rr|default('') else 'False' }}
+    client-reflect: {{ bgp.rr|default('')|bool }}
     # family: cannot disable this
     # ipv4: False # Enabled by default, disable globally and set per group
     group:
@@ -24,8 +24,8 @@ updates:
     - group-name: "{{c}}"
       admin-state: enable
       family:
-       ipv4: {{ 'ipv4' in bgp }}
-       ipv6: {{ 'ipv6' in bgp }}
+       ipv4: {{ 'ipv4' in bgp.address_families[bgp_type] }}
+       ipv6: {{ 'ipv6' in bgp.address_families[bgp_type] }}
       import:
        policy: ["accept_all"]
       export:

--- a/netsim/ansible/templates/bgp/sros.gnmi.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.j2
@@ -9,8 +9,8 @@ updates:
      import: False
      export: False
     multipath:
-     ibgp: {{ 16 if 'ixr' in type else 64 }}
-     ebgp: {{ 16 if 'ixr' in type else 64 }}
+     ibgp: {{ 16 if 'ixr' in clab.type else 64 }}
+     ebgp: {{ 16 if 'ixr' in clab.type else 64 }}
     min-route-advertisement: 1 # Be aggressive about sending updates
     connect-retry: 5           # Retry frequently, suitable in DC context
     client-reflect: {{ 'True' if bgp.rr|default('') else 'False' }}

--- a/netsim/ansible/templates/initial/sros.gnmi.j2
+++ b/netsim/ansible/templates/initial/sros.gnmi.j2
@@ -43,7 +43,7 @@
 {%- endmacro -%}
 
 updates:
-{% if 'ixr' in type %}
+{% if 'ixr' in clab.type %}
 - path: configure/system/resource
   val:
    ecmp-profile:
@@ -56,7 +56,7 @@ updates:
 {# Enable ECMP=64 by default #}
 - path: configure/router[router-name=Base]
   val:
-   ecmp: {{ 1 if 'ixr' in type else 64 }}
+   ecmp: {{ 1 if 'ixr' in clab.type else 64 }}
 {% if loopback.ipv4|default('')|ipv4 or 'ipv6' in loopback %}
 {% set v4 = loopback.ipv4|default('') %}
 {% set v6 = loopback.ipv6|default('') %}

--- a/netsim/ansible/templates/srv6/sros.gnmi.j2
+++ b/netsim/ansible/templates/srv6/sros.gnmi.j2
@@ -1,0 +1,143 @@
+{% if 'ixr' in type %}
+{{ raise_error | mandatory( 'SRv6 not supported on IXR platform' ) }}
+{% endif %}
+
+{% set locator_name = "JvB" %}
+{% set srv6_interfaces = interfaces|selectattr('isis','defined')|list %}
+updates:
+- path: configure/router[router-name=Base]/segment-routing/segment-routing-v6
+  val:
+   locator:
+   - locator-name: {{ locator_name }}
+     admin-state: enable
+     prefix:
+      ip-prefix: {{ srv6.locator }}
+     block-length: 48 # Part of locator that is shared between nodes in domain
+     static-function:
+      max-entries: {{ 1 + srv6_interfaces|length }} # 1 for node, 1 per interface
+{%   if srv6.fpe|default(False) %}
+     termination-fpe: [2]
+{%   endif %}
+
+   base-routing-instance:
+    locator:
+    - locator-name: {{ locator_name }}
+      function:
+       end:
+       - value: 1      # Static node end SID
+         srh-mode: usp # Ultimate Segment Pop
+       end-x:
+{%     for i in srv6_interfaces %}
+       - value: {{ 1 + loop.index }}
+         protection: protected
+         interface-name: {{ 'i' + i.ifname }}
+{%     endfor %}
+{%     if 'bgp' in module and srv6.bgp|default(False) and srv6.fpe|default(False) %}
+{%     if 'ipv4' in srv6.address_families %}
+       end-dt4: { }
+{%     endif %}
+{%     if 'ipv6' in srv6.address_families %}
+       end-dt6: { }
+{%     endif %}
+{%     endif %}
+   source-address: "{{ loopback.ipv6 | ipaddr('address') }}"
+{% if srv6.fpe|default(False) %}
+   origination-fpe: [1]
+{% endif %}
+
+{% if 'isis' in module and srv6.isis|default(False) %}
+- path: configure/router[router-name=Base]/isis[isis-instance=0]
+  val:
+   advertise-router-capability: area
+   ipv6-routing: native # Enables IS-IS IPv6 TLVs for IPv6 routing and enables support for native IPv6 TLVs.
+   loopfree-alternate: # Required for 'protected' auto-generated end.x SIDs
+    # remote-lfa:
+    #  node-protect: { }
+    ti-lfa:
+     node-protect: { }
+   segment-routing-v6:
+    admin-state: enable
+    locator:
+    - locator-name: {{ locator_name }}
+      level-capability: "{{ '2' if isis.type=='level-2' else ('1' if isis.type=='level-1' else '1/2') }}"
+{%    if 'isis' in srv6 and (srv6.isis.metric is defined or srv6.isis.cost is defined) %}
+      level:
+{%    for level in ['1','2'] %}
+      - level-number: "{{ level }}"
+        metric: {{ srv6.isis.metric|default(srv6.isis.cost) }}
+{%    endfor %}
+{%    endif %}
+
+{% endif %}
+
+{# Enable BGP SRv6 and/or extended NH encoding #}
+{% if 'bgp' in module %}
+{% if srv6.bgp|default(False) %}
+- path: configure/router[router-name=Base]/bgp
+  val:
+   segment-routing-v6:
+    source-address: "{{ loopback.ipv6 | ipaddr('address') }}"
+    family:
+{%  for af in srv6.address_families %}
+    - family-type: {{ af }}
+      ignore-received-srv6-tlvs: False # default: True
+      add-srv6-tlvs:
+       locator-name: {{ locator_name }}
+{%  endfor %}
+{% endif %}
+
+{% if 'ipv4' in srv6.address_families and (srv6.bgp|default(False) or bgp.rr|default(False)) %}
+- path: configure/router[router-name=Base]/bgp
+  val:
+   extended-nh-encoding:
+    ipv4: True
+   advertise-ipv6-next-hops:
+    ipv4: True
+{% endif %}
+{% endif %}
+
+{# Provision SRv6 FPE resources at edges of SRv6 domain #}
+{% if srv6.fpe|default(False) %}
+{# MAC chip loopbacks #}
+- path: configure/card[slot-number=1]/mda[mda-slot=1]/xconnect
+  val:
+   mac:
+   - mac-id: 1
+     loopback:
+     - loopback-id: 1
+     - loopback-id: 2
+
+- path: configure/port-xc
+  val:
+   pxc:
+   - pxc-id: 1
+     port-id: 1/1/m1/1
+     admin-state: enable
+     description: "SRv6 origination"
+   - pxc-id: 2
+     port-id: 1/1/m1/2
+     admin-state: enable
+     description: "SRv6 termination"
+
+{% for id in ['pxc-1.a','pxc-1.b','pxc-2.a','pxc-2.b','1/1/m1/1','1/1/m1/2'] %}
+- path: configure/port[port-id={{id}}]
+  val:
+   admin-state: enable
+{% endfor %}
+
+- path: configure/fwd-path-ext
+  val:
+   fpe:
+   - fpe-id: 1
+     path:
+      pxc: 1
+     application:
+      srv6:
+       type: origination # One per system
+   - fpe-id: 2
+     path:
+      pxc: 2
+     application:
+      srv6:
+       type: termination
+{% endif %}

--- a/netsim/ansible/templates/srv6/sros.gnmi.j2
+++ b/netsim/ansible/templates/srv6/sros.gnmi.j2
@@ -15,7 +15,7 @@ updates:
      block-length: 48 # Part of locator that is shared between nodes in domain
      static-function:
       max-entries: {{ 1 + srv6_interfaces|length }} # 1 for node, 1 per interface
-{%   if srv6.fpe|default(False) %}
+{%   if not srv6.transit_only|default(False) %}
      termination-fpe: [2]
 {%   endif %}
 
@@ -32,7 +32,7 @@ updates:
          protection: protected
          interface-name: {{ 'i' + i.ifname }}
 {%     endfor %}
-{%     if 'bgp' in module and srv6.bgp|default(False) and srv6.fpe|default(False) %}
+{%     if 'bgp' in module and srv6.bgp|default(False) and not srv6.transit_only|default(False) %}
 {%     if 'ipv4' in srv6.address_families %}
        end-dt4: { }
 {%     endif %}
@@ -41,7 +41,7 @@ updates:
 {%     endif %}
 {%     endif %}
    source-address: "{{ loopback.ipv6 | ipaddr('address') }}"
-{% if srv6.fpe|default(False) %}
+{% if not srv6.transit_only|default(False) %}
    origination-fpe: [1]
 {% endif %}
 
@@ -97,7 +97,7 @@ updates:
 {% endif %}
 
 {# Provision SRv6 FPE resources at edges of SRv6 domain #}
-{% if srv6.fpe|default(False) %}
+{% if not srv6.transit_only|default(False) %}
 {# MAC chip loopbacks #}
 - path: configure/card[slot-number=1]/mda[mda-slot=1]/xconnect
   val:

--- a/netsim/ansible/templates/srv6/sros.gnmi.j2
+++ b/netsim/ansible/templates/srv6/sros.gnmi.j2
@@ -1,4 +1,4 @@
-{% if 'ixr' in type %}
+{% if 'ixr' in clab.type %}
 {{ raise_error | mandatory( 'SRv6 not supported on IXR platform' ) }}
 {% endif %}
 

--- a/netsim/modules/srv6.py
+++ b/netsim/modules/srv6.py
@@ -23,9 +23,5 @@ class SRV6(_Module):
 
       node.srv6.locator = str( locator )
 
-      # if node.srv6.get('fpe',False):
-      #    if_format = topology.defaults.devices[node.device].interface_name
-      #    node.srv6.fpe_port = if_format % (1+len(node.get('interfaces',[])))
-
       # TODO process per-interface srv6 parameters?
       # for l in node.get('interfaces',[]):

--- a/netsim/modules/srv6.py
+++ b/netsim/modules/srv6.py
@@ -5,7 +5,7 @@ from box import Box
 
 from . import _Module
 from .. import addressing, common
-import ipaddr
+import ipaddr # type: ignore
 
 class SRV6(_Module):
 

--- a/netsim/modules/srv6.py
+++ b/netsim/modules/srv6.py
@@ -1,0 +1,31 @@
+#
+# SRv6 transformation module
+#
+from box import Box
+
+from . import _Module
+from .. import addressing, common
+import ipaddr
+
+class SRV6(_Module):
+
+  def node_post_transform(self, node: Box, topology: Box) -> None:
+
+      # Could model this as another addressing pool too
+      locator = ipaddr.IPv6Network( f'{topology.defaults.srv6.locator}:{node.id:x}::/64' )
+
+      if 'ipv6' not in node.loopback:
+          common.error( "SRv6 requires an ipv6 loopback address",
+                        common.MissingValue, 'srv6' )
+      elif locator.overlaps( ipaddr.IPNetwork(node.loopback.ipv6) ):
+          common.error( f"Node ipv6 loopback address {node.loopback.ipv6} overlaps with locator {locator}",
+                        common.IncorrectValue, 'srv6' )
+
+      node.srv6.locator = str( locator )
+
+      # if node.srv6.get('fpe',False):
+      #    if_format = topology.defaults.devices[node.device].interface_name
+      #    node.srv6.fpe_port = if_format % (1+len(node.get('interfaces',[])))
+
+      # TODO process per-interface srv6 parameters?
+      # for l in node.get('interfaces',[]):

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -99,7 +99,7 @@ srv6:
   isis: True
   attributes:
     global: [ locator, address_families, bgp, isis ]
-    node: [ locator, address_families, bgp, isis, fpe ]
+    node: [ locator, address_families, bgp, isis, transit_only ]
 
 #
 # Provider defaults

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -36,14 +36,17 @@ bgp:
   ebgp_role: external
   advertise_roles: [ stub ]
   advertise_loopback: True
+  address_families:
+    ibgp: [ ipv4, ipv6 ]
+    ebgp: [ ipv4, ipv6 ]
   community:
     ibgp: [ standard, extended ]
     ebgp: [ standard ]
   no_propagate: [ ebgp_role, advertise_roles, rr_list, as_list ]
   next_hop_self: true
   attributes:
-    global: [ as, next_hop_self, rr_list, ebgp_role, as_list, advertise_loopback, advertise_roles, community ]
-    node: [ as, next_hop_self, rr, originate, advertise_loopback, community, router_id ]
+    global: [ as, next_hop_self, rr_list, ebgp_role, as_list, advertise_loopback, advertise_roles, community, address_families ]
+    node: [ as, next_hop_self, rr, originate, advertise_loopback, community, router_id, address_families ]
     link: [ advertise ]
 
 isis:
@@ -85,6 +88,18 @@ sr:
   attributes:
     global: [ srgb_range_start, srgb_range_size, ipv6_sid_offset ]
     node: [ srgb_range_start, srgb_range_size, ipv6_sid_offset ]
+
+srv6:
+  requires: [ isis ]
+  supported_on: [ sros ]
+  locator: 2001:db8:aaaa # 2001:db8::/32 see RFC 6890 – Documentation Set
+  address_families: [ ipv4, ipv6 ]
+  # protocols: [ isis ] # Could model like this too
+  bgp: False
+  isis: True
+  attributes:
+    global: [ locator, address_families, bgp, isis ]
+    node: [ locator, address_families, bgp, isis, fpe ]
 
 #
 # Provider defaults

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -87,6 +94,13 @@ name: input
 nodes:
   r1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -193,6 +207,13 @@ nodes:
     router_id: 10.0.0.7
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -296,6 +317,13 @@ nodes:
     router_id: 10.0.0.21
   r3:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -373,6 +401,13 @@ nodes:
     router_id: 10.0.0.42
   r4:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -38,6 +45,13 @@ name: input
 nodes:
   l1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -89,6 +103,13 @@ nodes:
       router_id: 10.0.0.1
   l2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       anycast: 10.42.42.42/32
       as: 65000

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   advertise_roles:
   - stub
@@ -166,6 +173,13 @@ name: input
 nodes:
   a1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: false
       as: 65101
       community:
@@ -223,6 +237,13 @@ nodes:
       router_id: 10.0.0.5
   a2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: false
       as: 65101
       community:
@@ -280,6 +301,13 @@ nodes:
       router_id: 10.0.0.6
   a3:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: false
       as: 65101
       community:
@@ -337,6 +365,13 @@ nodes:
       router_id: 10.0.0.7
   l1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -389,6 +424,13 @@ nodes:
       router_id: 10.0.0.1
   l2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -477,6 +519,13 @@ nodes:
       router_id: 10.0.0.2
   l3:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -547,6 +596,13 @@ nodes:
       router_id: 10.0.0.3
   s1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -17,6 +24,13 @@ name: input
 nodes:
   r1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -54,6 +68,13 @@ nodes:
       router_id: 10.0.0.1
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -93,6 +114,13 @@ nodes:
       router_id: 10.0.0.2
   r3:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -95,6 +102,13 @@ name: input
 nodes:
   l1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -171,6 +185,13 @@ nodes:
       unnumbered: true
   l2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -247,6 +268,13 @@ nodes:
       unnumbered: true
   s1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -327,6 +355,13 @@ nodes:
       unnumbered: true
   s2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as_list:
     65000:
@@ -159,6 +166,13 @@ name: input
 nodes:
   e1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65001
       community:
@@ -204,6 +218,13 @@ nodes:
     name: e1
   e2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65002
       community:
@@ -249,6 +270,13 @@ nodes:
     name: e2
   pe1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -328,6 +356,13 @@ nodes:
     name: pe1
   pe2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -407,6 +442,13 @@ nodes:
     name: pe2
   rr1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -472,6 +514,13 @@ nodes:
     name: rr1
   rr2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as_list:
     65000:
@@ -79,6 +86,13 @@ name: input
 nodes:
   r1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -132,6 +146,13 @@ nodes:
     name: r1
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65100
       community:
@@ -203,6 +224,13 @@ nodes:
     name: r2
   r3:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65200
       community:

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -206,6 +213,13 @@ name: input
 nodes:
   e1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65001
       community:
@@ -268,6 +282,13 @@ nodes:
       router_id: 10.0.0.5
   e2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65002
       community:
@@ -376,6 +397,13 @@ nodes:
     name: nar
   pe1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -475,6 +503,13 @@ nodes:
       router_id: 10.0.0.3
   pe2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -574,6 +609,13 @@ nodes:
       router_id: 10.0.0.4
   rr1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -660,6 +702,13 @@ nodes:
       router_id: 10.0.0.1
   rr2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -31,6 +38,13 @@ name: input
 nodes:
   a:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -65,6 +79,13 @@ nodes:
     name: a
   b:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -99,6 +120,13 @@ nodes:
     name: b
   c:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -133,6 +161,13 @@ nodes:
     name: c
   d:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65001
       community:
@@ -167,6 +202,13 @@ nodes:
     name: d
   e:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65001
       community:
@@ -201,6 +243,13 @@ nodes:
     name: e
   f:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -34,6 +41,13 @@ nodes:
       router_id: 10.0.0.1
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   community:
     ebgp:
@@ -37,6 +44,13 @@ nodes:
       router_id: 10.0.0.1
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/module-node-only.yml
+++ b/tests/topology/expected/module-node-only.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   community:
     ebgp:
@@ -37,6 +44,13 @@ nodes:
       router_id: 10.0.0.1
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -35,6 +42,13 @@ nodes:
       router_id: 0.0.0.17
   r2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   community:
     ebgp:
@@ -104,6 +111,13 @@ name: input
 nodes:
   c1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -224,6 +238,13 @@ nodes:
     name: c2
   e1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:
@@ -295,6 +316,13 @@ nodes:
     name: e1
   e2:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/unroll.yml
+++ b/tests/topology/expected/unroll.yml
@@ -1,4 +1,11 @@
 bgp:
+  address_families:
+    ebgp:
+    - ipv4
+    - ipv6
+    ibgp:
+    - ipv4
+    - ipv6
   advertise_loopback: true
   as: 65000
   community:
@@ -21,6 +28,13 @@ name: input
 nodes:
   rr1:
     bgp:
+      address_families:
+        ebgp:
+        - ipv4
+        - ipv6
+        ibgp:
+        - ipv4
+        - ipv6
       advertise_loopback: true
       as: 65001
       community:


### PR DESCRIPTION
I've tried to minimize the deltas required to implement this, this PR proposes to add an 'address_families' knob for bgp to provide more control over the enabled protocols (to be extended to include evpn in the near future)