### PR TITLE
switch to router_id for ospf & bgp

### DIFF
--- a/netsim/ansible/tasks/fortinet.fortios.fortios/ospf.yml
+++ b/netsim/ansible/tasks/fortinet.fortios.fortios/ospf.yml
@@ -6,7 +6,7 @@
       area:
         - id: "{{ ospf.area | ansible.netcommon.ipaddr('address') | default('0.0.0.0') }}"
       auto_cost_ref_bandwidth: "{{ ospf.reference_bandwidth | default(omit) }}"
-      router_id: "{{ loopback.ipv4 | ipaddr('address') | default(omit) }}"
+      router_id: "{{ ospf.router_id }}"
 
 - name: Configure OSPF on loopback
   fortinet.fortios.fortios_router_ospf:

--- a/netsim/ansible/templates/bgp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/bgp/cumulus_nvue.j2
@@ -71,8 +71,8 @@
 {%     endfor %}
 {%   endif %}
 {% endfor %}
-{% if 'ipv4' in loopback %}
-            router-id: {{ loopback.ipv4 | ansible.netcommon.ipaddr('address') }}
+{% if 'router_id' in bgp %}
+            router-id: {{ bgp.router_id }}
 {% endif %}
 {% if bgp.originate is defined %}
           static:

--- a/netsim/ansible/templates/ospf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/ospf/cumulus_nvue.j2
@@ -10,12 +10,12 @@
 {% if ospf.reference_bandwidth is defined %}
             reference-bandwidth: {{ ospf.reference_bandwidth }}
 {% endif %}
-{% if 'ipv4' in loopback %}
-            router-id: {{ router_id }}
+{% if 'router_id' in ospf %}
+            router-id: {{ ospf.router_id }}
             area:
               '{{ ospf.area }}':
                 network:
-                  {{ router_id }}: {}
+                  {{ ospf.router_id }}: {}
 {% endif %}
 {% for l in interfaces|default([]) if 'ospf' in l %}
 {%   if loop.first %}


### PR DESCRIPTION
Fixes for https://github.com/ipspace/netsim-tools/issues/148

Platforms:
- Cumulus NVUE:
  - Fixed ospf template to use router_id
  - Fixed bgp template to use router_id
- Fortinet:
  - Fixed ospf template to use router_id