### PR TITLE
SR OS and SR Linux set custom port mtu

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -24,13 +24,14 @@ updates:
 {% if mtu is defined %}
 {% if (clab.type in ['ixr6','ixr10'] and mtu>9486)
    or (clab.type in ['ixrd1','ixrd2','ixrd3','ixrh1','ixrh2'] and mtu>9398) %}
-  {{ mtu_too_large | mandatory( 'MTU '+str(mtu)+' too large for given hardware platform: ' + clab.type ) }}
+{{ mtu_too_large | mandatory( 'MTU '+str(mtu)+' too large for given hardware platform: ' + clab.type ) }}
 {% else %}
 - path: system/mtu
   val:
-   default-port-mtu: {{ mtu + 14 }}
-   default-l2-mtu: {{ mtu + 14 }}
+   default-port-mtu: {{ [mtu + 14,1500]|max }}
+   default-l2-mtu: {{ [mtu + 14,1500]|max }}
    default-ip-mtu: {{ mtu }}
+{% endif %}
 {% endif %}
 - path: interface[name=system0]/subinterface[index=0]
   val:

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -46,8 +46,8 @@ updates:
 {% elif l.type|default("") == "stub" %}
    description: "Stub interface"
 {% endif %}
-{% if l.mtu is defined %}
-   mtu {{ l.mtu }} # TODO not supported on loopback interfaces
+{% if l.mtu is defined %} # min 1500; max 9412 for 7220, 9500 for 7250 platforms
+   mtu {{ [l.mtu + 14,1500]|max }} # TODO not supported on loopback interfaces
 {% endif %}
    subinterface:
     index: 0

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -21,6 +21,17 @@
 {% endmacro %}
 
 updates:
+{% if mtu is defined %}
+{% if (clab.type in ['ixr6','ixr10'] and mtu>9486)
+   or (clab.type in ['ixrd1','ixrd2','ixrd3','ixrh1','ixrh2'] and mtu>9398) %}
+  {{ mtu_too_large | mandatory( 'MTU '+str(mtu)+' too large for given hardware platform: ' + clab.type ) }}
+{% else %}
+- path: system/mtu
+  val:
+   default-port-mtu: {{ mtu + 14 }}
+   default-l2-mtu: {{ mtu + 14 }}
+   default-ip-mtu: {{ mtu }}
+{% endif %}
 - path: interface[name=system0]/subinterface[index=0]
   val:
 {{  ip_addresses(loopback,False,True)  }}
@@ -32,6 +43,9 @@ updates:
    description: "{{ l.name|replace('->','~')|regex_replace('[\\[\\]]','') }}{{ " ("+l.role+")" if l.role is defined else '' }}"
 {% elif l.type|default("") == "stub" %}
    description: "Stub interface"
+{% endif %}
+{% if l.mtu is defined %}
+   mtu {{ l.mtu }} # TODO not supported on loopback interfaces
 {% endif %}
    subinterface:
     index: 0

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -22,15 +22,16 @@
 
 updates:
 {% if mtu is defined %}
-{% if (clab.type in ['ixr6','ixr10'] and mtu>9486)
-   or (clab.type in ['ixrd1','ixrd2','ixrd3','ixrh1','ixrh2'] and mtu>9398) %}
-{{ mtu_too_large | mandatory( 'MTU '+str(mtu)+' too large for given hardware platform: ' + clab.type ) }}
+{% if (clab.type in ['ixr6','ixr10'] and (mtu+14)>9486)
+   or (clab.type in ['ixrd1','ixrd2','ixrd3','ixrh1','ixrh2'] and (mtu+14)>9398) %}
+{{ mtu_too_large | mandatory( 'IP MTU '+str(mtu)+' too large for given hardware platform: ' + clab.type ) }}
 {% else %}
 - path: system/mtu
   val:
    default-port-mtu: {{ [mtu + 14,1500]|max }}
    default-l2-mtu: {{ [mtu + 14,1500]|max }}
    default-ip-mtu: {{ mtu }}
+   _annotate_default-ip-mtu: "Custom system wide setting, overrides default 1500"
 {% endif %}
 {% endif %}
 - path: interface[name=system0]/subinterface[index=0]

--- a/netsim/ansible/templates/initial/sros.gnmi.j2
+++ b/netsim/ansible/templates/initial/sros.gnmi.j2
@@ -80,6 +80,12 @@ updates:
 {% else %}
 {% set portname = l.ifname %}
 {% endif %}
+{% if l.mtu is defined and l.mtu <= 9800 %}
+- path: configure/port[port-id={{ portname }}]
+  val:
+   ethernet:
+    mtu: {{ l.mtu }} # max 9800
+{% endif %}
 {% if v4|ipv4 or v6|ipv6 or l.unnumbered|default(0) or v4==True or v6==True %}
 {{ interface('i'+l.ifname,desc,v4,v6,portname) }}
 {% else %}

--- a/netsim/ansible/templates/initial/sros.gnmi.j2
+++ b/netsim/ansible/templates/initial/sros.gnmi.j2
@@ -80,11 +80,11 @@ updates:
 {% else %}
 {% set portname = l.ifname %}
 {% endif %}
-{% if l.mtu is defined and l.mtu <= 9800 %}
+{% if l.mtu is defined and l.mtu <= (9800-14) %}
 - path: configure/port[port-id={{ portname }}]
   val:
    ethernet:
-    mtu: {{ l.mtu }} # max 9800
+    mtu: {{ l.mtu + 14 }} # max 9800
 {% endif %}
 {% if v4|ipv4 or v6|ipv6 or l.unnumbered|default(0) or v4==True or v6==True %}
 {{ interface('i'+l.ifname,desc,v4,v6,portname) }}

--- a/netsim/ansible/templates/ospf/sros.gnmi.j2
+++ b/netsim/ansible/templates/ospf/sros.gnmi.j2
@@ -27,7 +27,7 @@ updates:
 {%       if l.ospf.bfd|default(False) %}
          bfd-liveness: { }
 {%       endif %}
-         mtu: 1500 # SRL defaults to 1500
+         # mtu: 1500 # SRL defaults to 1500, now supporting global mtu settings
 {# TODO: Add support for multi-area adjacencies and 'secondary' interface-type #}
 {%       if l.ospf.network_type|default("") in ["broadcast","non-broadcast","point-to-point"] %}
          interface-type: "{{ l.ospf.network_type }}"

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -457,6 +457,20 @@ devices:
         name: e1-%d
       group_vars:
         srlinux_grpc_port: 57400
+    features:
+      initial:
+        system_mtu: True
+        ipv4:
+          unnumbered: False
+        ipv6:
+          lla: True
+      ospf:
+        unnumbered: False
+      isis:
+        unnumbered:
+          ipv4: False
+          ipv6: True
+          network: False
 
   sros:
     mgmt_if: A/1


### PR DESCRIPTION
See https://github.com/ipspace/netsim-tools/issues/171

Note that the maximum supported L2 MTU on SR OS is 9800, any larger values are currently ignored without warning.
We may want to add a sanity check and min/max supported values per device in topology-defaults.yml