### PR TITLE
Determine same iBGP RR cluster-id for redundant clusters

### DIFF
--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -69,7 +69,7 @@ protocols {
       advertise-inactive;
       local-address {{ loopback[af]|ipaddr('address') }};
 {%   if bgp.rr is defined %}
-      cluster {{ bgp.router_id|ipaddr('address') }};
+      cluster {{ bgp.rr_cluster_id }};
 {%   endif %}
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
       neighbor {{ n[af] }} {

--- a/netsim/ansible/templates/bgp/srlinux.cli.j2
+++ b/netsim/ansible/templates/bgp/srlinux.cli.j2
@@ -43,7 +43,7 @@ send-community large {{ 'true' if 'large' in list else 'false' }}
 #}
 {% if g=='ibgp' and bgp.rr|default(0)|bool %}
  route-reflector {
-  cluster-id {{ bgp.router_id }}
+  cluster-id {{ bgp.rr_cluster_id }}
   client true
  }
  next-hop-self false

--- a/netsim/ansible/templates/bgp/srlinux.j2
+++ b/netsim/ansible/templates/bgp/srlinux.j2
@@ -57,7 +57,7 @@ updates:
 #}
 {%   if ibgp_rr %}
      route-reflector:
-      cluster-id: {{ bgp.router_id }}
+      cluster-id: {{ bgp.rr_cluster_id }}
       client: True
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/bgp/sros.gnmi.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.j2
@@ -46,7 +46,7 @@ updates:
       local-address: "{{ loopback[ c[5:] ]|ipaddr('address') }}"
 {%    if bgp.rr|default('')|bool %}
       cluster:
-        cluster-id: "{{ bgp.router_id }}"
+        cluster-id: "{{ bgp.rr_cluster_id }}"
 {%    elif bgp.next_hop_self|default(false) %}
       next-hop-self: True
 {%    endif %}

--- a/netsim/ansible/templates/bgp/sros.openconfig.j2
+++ b/netsim/ansible/templates/bgp/sros.openconfig.j2
@@ -40,7 +40,7 @@ updates:
 {%       if bgp.rr|default(0)|bool and c=='ibgp' %}
          route-reflector:
           config:
-           route-reflector-cluster-id: "{{ bgp.router_id }}"
+           route-reflector-cluster-id: "{{ bgp.rr_cluster_id }}"
 {%       endif %}
 {%     endfor %}
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -85,7 +85,6 @@ class BGP(_Module):
       return
 
     node_data = Box({},default_box=True,box_dots=True)
-    cluster_id_per_asn = {} # Lowest route reflector ID per AS, to use as cluster
     for asn,data in topology.bgp.as_list.items():
       if not isinstance(data,Box):
         common.error(
@@ -127,9 +126,6 @@ class BGP(_Module):
             common.IncorrectValue)
           continue
         node_data[n].rr = True
-        router_id = netaddr.IPAddress(topology.nodes[n].router_id)
-        if asn not in cluster_id_per_asn or cluster_id_per_asn[asn] > router_id:
-          cluster_id_per_asn[asn] = router_id
 
     for name,node in topology.nodes.items():
       if name in node_data:
@@ -141,8 +137,6 @@ class BGP(_Module):
           continue
 
         node.bgp = node_data[name] + node.bgp
-        if 'rr' in node.bgp and node_as in cluster_id_per_asn:
-          node.bgp.cluster_id = cluster_id_per_asn[node_as].ipv4()
 
   '''
   bgp_build_group: create automatic groups based on BGP AS numbers
@@ -225,11 +219,17 @@ class BGP(_Module):
         if "bgp" in n:
           if n.bgp.get("as") == node.bgp.get("as") and n.name != node.name:
             node.bgp.neighbors.append(bgp_neighbor(n,n.loopback,'ibgp',get_neighbor_rr(n)))
+
     #
     # The node is not a route reflector, and we have a non-empty RR list
     # We need BGP sessions with the route reflectors
     else:
+
+      # To support multiple redundant route reflectors, pick a common cluster id
+      cluster_id = min( [ netaddr.IPAddress(n.router_id) for n in rrlist ] ).ipv4()
+
       for n in rrlist:
+        n.bgp.cluster_id = cluster_id
         if n.name != node.name:
           node.bgp.neighbors.append(bgp_neighbor(n,n.loopback,'ibgp',get_neighbor_rr(n)))
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -226,10 +226,10 @@ class BGP(_Module):
     else:
 
       # To support multiple redundant route reflectors, pick a common cluster id
-      cluster_id = min( [ netaddr.IPAddress(n.bgp.router_id) for n in rrlist ] ).ipv4()
+      cluster_id = f"0.0.0.{ min( [ n.id for n in rrlist ] ) % 256 }"
 
       for n in rrlist:
-        n.bgp.cluster_id = cluster_id
+        n.bgp.rr_cluster_id = cluster_id
         if n.name != node.name:
           node.bgp.neighbors.append(bgp_neighbor(n,n.loopback,'ibgp',get_neighbor_rr(n)))
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -226,7 +226,7 @@ class BGP(_Module):
     else:
 
       # To support multiple redundant route reflectors, pick a common cluster id
-      cluster_id = min( [ netaddr.IPAddress(n.router_id) for n in rrlist ] ).ipv4()
+      cluster_id = min( [ netaddr.IPAddress(n.bgp.router_id) for n in rrlist ] ).ipv4()
 
       for n in rrlist:
         n.bgp.cluster_id = cluster_id

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -572,6 +572,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.4
       rr: true
+      rr_cluster_id: 0.0.0.4
     box: cisco/iosv
     device: iosv
     id: 4

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -273,6 +273,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.3
       rr: true
+      rr_cluster_id: 0.0.0.3
     box: cisco/nexus9300v
     device: nxos
     id: 3
@@ -353,6 +354,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.4
       rr: true
+      rr_cluster_id: 0.0.0.3
     box: cisco/nexus9300v
     device: nxos
     id: 4

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -433,6 +433,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.1
       rr: true
+      rr_cluster_id: 0.0.0.1
     box: cisco/iosv
     device: iosv
     id: 1
@@ -498,6 +499,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.2
       rr: true
+      rr_cluster_id: 0.0.0.1
     box: cisco/iosv
     device: iosv
     id: 2

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -604,6 +604,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.1
       rr: true
+      rr_cluster_id: 0.0.0.1
     box: cisco/iosv
     device: iosv
     id: 1
@@ -690,6 +691,7 @@ nodes:
       next_hop_self: true
       router_id: 10.0.0.2
       rr: true
+      rr_cluster_id: 0.0.0.1
     box: cisco/iosv
     device: iosv
     id: 2


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/html/rfc4456#section-7 - a cluster of iBGP route reflectors should be configured with the same cluster-id as a loop prevention measure.

This patch calculates abgp.rr_cluster_id using the lowest id of the rr nodes