### PR TITLE
Make BGP cluster ID optional

### DIFF
--- a/netsim/ansible/templates/bgp/cumulus.j2
+++ b/netsim/ansible/templates/bgp/cumulus.j2
@@ -10,7 +10,7 @@ router bgp {{ bgp.as }}
 {% if bgp.router_id|ipv4 %}
   bgp router-id {{ bgp.router_id }}
 {% endif %}
-{% if bgp.rr_cluster_id is defined %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
   bgp cluster-id {{ bgp.rr_cluster_id }}
 {% endif %}
 !

--- a/netsim/ansible/templates/bgp/eos.j2
+++ b/netsim/ansible/templates/bgp/eos.j2
@@ -29,7 +29,7 @@ router bgp {{ bgp.as }}
 {% if bgp.router_id|ipv4 %}
   router-id {{ bgp.router_id }}
 {% endif %}
-{% if bgp.rr_cluster_id is defined %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
   bgp cluster-id {{ bgp.rr_cluster_id }}
 {% endif %}
 {% if bgp.rr|default('') %}

--- a/netsim/ansible/templates/bgp/frr.j2
+++ b/netsim/ansible/templates/bgp/frr.j2
@@ -10,7 +10,7 @@ router bgp {{ bgp.as }}
 {% if bgp.router_id|ipv4 %}
   bgp router-id {{ bgp.router_id }}
 {% endif %}
-{% if bgp.rr_cluster_id is defined %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
   bgp cluster-id {{ bgp.rr_cluster_id }}
 {% endif %}
 !

--- a/netsim/ansible/templates/bgp/ios.j2
+++ b/netsim/ansible/templates/bgp/ios.j2
@@ -49,7 +49,7 @@ router bgp {{ bgp.as }}
 {% if bgp.router_id|ipv4 %}
   bgp router-id {{ bgp.router_id }}
 {% endif %}
-{% if bgp.rr_cluster_id is defined %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
   bgp cluster-id {{ bgp.rr_cluster_id }}
 {% endif %}
 {#

--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -62,15 +62,15 @@ protocols {
 }
 protocols {
   bgp {
-{% for af in ['ipv4','ipv6'] if bgp[af] is defined %}
+{% for af in ['ipv4','ipv6'] if bgp[af] is defined and loopback[af] is defined %}
     group ibgp-peers-{{ af }} {
       type internal;
       export ibgp-export;
       advertise-inactive;
-      local-address {{ bgp.router_id }};
-{%   if bgp.rr is defined %}
-      cluster {{ bgp.rr_cluster_id }};
-{%   endif %}
+      local-address {{ loopback[af]|ipaddr('address') }};
+{% if bgp.rr|default(False) %}
+      cluster {{ bgp.rr_cluster_id|default(False) or bgp.router_id }};
+{% endif %}
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
       neighbor {{ n[af] }} {
         description {{ n.name }};

--- a/netsim/ansible/templates/bgp/nxos.j2
+++ b/netsim/ansible/templates/bgp/nxos.j2
@@ -8,7 +8,7 @@ router bgp {{ bgp.as }}
 {% if bgp.router_id|ipv4 %}
   router-id {{ bgp.router_id }}
 {% endif %}
-{% if bgp.rr_cluster_id is defined %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
   cluster-id {{ bgp.rr_cluster_id }}
 {% endif %}
 {% for af in ['ipv4','ipv6'] if bgp [af] is defined %}

--- a/netsim/ansible/templates/bgp/srlinux.cli.j2
+++ b/netsim/ansible/templates/bgp/srlinux.cli.j2
@@ -43,7 +43,7 @@ send-community large {{ 'true' if 'large' in list else 'false' }}
 #}
 {% if g=='ibgp' and bgp.rr|default(0)|bool %}
  route-reflector {
-  cluster-id {{ bgp.rr_cluster_id }}
+  cluster-id {{ bgp.rr_cluster_id|default(False) or bgp.router_id }}
   client true
  }
  next-hop-self false

--- a/netsim/ansible/templates/bgp/srlinux.j2
+++ b/netsim/ansible/templates/bgp/srlinux.j2
@@ -57,7 +57,7 @@ updates:
 #}
 {%   if ibgp_rr %}
      route-reflector:
-      cluster-id: {{ bgp.rr_cluster_id }}
+      cluster-id: {{ bgp.rr_cluster_id|default(False) or bgp.router_id }}
       client: True
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/bgp/sros.gnmi.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.j2
@@ -46,7 +46,7 @@ updates:
       local-address: "{{ loopback[ c[5:] ]|ipaddr('address') }}"
 {%    if bgp.rr|default('')|bool %}
       cluster:
-        cluster-id: "{{ bgp.rr_cluster_id }}"
+        cluster-id: "{{ bgp.rr_cluster_id|default(False) or bgp.router_id }}"
 {%    elif bgp.next_hop_self|default(false) %}
       next-hop-self: True
 {%    endif %}

--- a/netsim/ansible/templates/bgp/sros.openconfig.j2
+++ b/netsim/ansible/templates/bgp/sros.openconfig.j2
@@ -40,7 +40,7 @@ updates:
 {%       if bgp.rr|default(0)|bool and c=='ibgp' %}
          route-reflector:
           config:
-           route-reflector-cluster-id: "{{ bgp.rr_cluster_id }}"
+           route-reflector-cluster-id: "{{ bgp.rr_cluster_id|default(False) or bgp.router_id }}"
 {%       endif %}
 {%     endfor %}
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -43,7 +43,7 @@ bgp:
   no_propagate: [ ebgp_role, advertise_roles, rr_list, as_list ]
   next_hop_self: true
   attributes:
-    global: [ as, next_hop_self, rr_list, ebgp_role, as_list, advertise_loopback, advertise_roles, community, address_families ]
+    global: [ as, next_hop_self, rr_cluster_id, rr_list, ebgp_role, as_list, advertise_loopback, advertise_roles, community, address_families ]
     node: [ as, next_hop_self, rr, rr_cluster_id, originate, advertise_loopback, community, router_id, address_families ]
     link: [ advertise ]
 


### PR DESCRIPTION
We might not want to enforce bgp.rr_cluster_id in all situations. Setting bgp.rr_cluster_id to False in node data does that, but that possibility has to be recognized in configuration templates.

There are two types of device configuration templates in regards to BGP RR cluster-id attribute:

* Devices that configure RR-clients on BGP sessions (IOS, EOS, NXOS, Cumulus...) -- on those devices we simply don't configure **cluster-id** if bgp.rr is not True or bgp.rr_cluster_id is not set.
* Devices that use **cluster-id** to change a BGP speaker into a route reflector -- on those devices we have to use **bgp.rr_cluster_id** or **bgp.router_id** as the cluster ID.

@jbemmel: Please check whether I made correct changes to SR Linux and SR OS templates. Thank you!