### PR TITLE
Always define node.interfaces

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -114,9 +114,6 @@ def get_link_base_attributes(defaults: Box) -> set:
   return get_link_full_attributes(defaults) - set(no_propagate)
 
 def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
-  if not 'interfaces' in node:
-    node.interfaces = []
-
   ifindex_offset = devices.get_device_attribute(node,'ifindex_offset',defaults)
   if ifindex_offset is None:
     ifindex_offset = 1
@@ -444,7 +441,7 @@ def set_link_type_role(link: Box, pools: Box, nodes: Box) -> None:
     if not 'role' in link:
       link.role = 'stub'
 
-  return 
+  return
 
 def check_link_type(data: Box) -> bool:
   node_cnt = data.get('node_count') # link_node_count(data,nodes)
@@ -452,7 +449,7 @@ def check_link_type(data: Box) -> bool:
 
   if 'mtu' in data and not isinstance(data.mtu,int): # pragma: no cover
     common.error(f'MTU parameter should be an integer: {data}',common.IncorrectValue,'links')
-    
+
   if not link_type: # pragma: no cover (shouldn't get here)
     common.fatal('Internal error: link type still undefined in check_link_type: %s' % data,'links')
     return False

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -46,6 +46,7 @@ def create_node_dict(nodes: Box) -> Box:
     node_dict[name] = ndata
 
   common.exit_on_error()
+  node_dict['interfaces'] = [] # Make sure node.interfaces is always defined
   return node_dict
 
 def augment_mgmt_if(node: Box, defaults: Box, addrs: typing.Optional[Box]) -> None:

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -43,10 +43,10 @@ def create_node_dict(nodes: Box) -> Box:
       node_dict[name] = { 'name': name, 'extra': ndata }
     else:
       ndata['name'] = name
+    ndata['interfaces'] = [] # Make sure node.interfaces is always defined
     node_dict[name] = ndata
 
   common.exit_on_error()
-  node_dict['interfaces'] = [] # Make sure node.interfaces is always defined
   return node_dict
 
 def augment_mgmt_if(node: Box, defaults: Box, addrs: typing.Optional[Box]) -> None:
@@ -89,7 +89,7 @@ def augment_node_provider_data(topology: Box) -> None:
     common.fatal('Device defaults (defaults.devices) are missing')
 
   for name,n in topology.nodes.items():
-    if not n.device:
+    if 'device' not in n:
       n.device = topology.defaults.device
 
     if not n.device:


### PR DESCRIPTION
Fixes https://github.com/ipspace/netsim-tools/issues/213

There are 92 cases of interfaces|default([]) in the templates that could be simplified