### PR TITLE
Enable Cumulus 5.0.1 NVUE for Clab

### DIFF
--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -1,3 +1,9 @@
+- name: "start nvue daemon"
+  command: systemctl start nvued
+
+- name: "enable nvue"
+  command: systemctl enable nvued
+
 - name: "copy the cumulus nvue yaml config file to switch for {{ config_module }} config"
   template:
     src: "{{ config_template }}"

--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -1,17 +1,28 @@
-- name: "start nvue daemon"
-  command: systemctl start nvued
-
-- name: "enable nvue"
-  command: systemctl enable nvued
-
-- name: "copy the cumulus nvue yaml config file to switch for {{ config_module }} config"
+- name: "copy the cumulus nvue YAML {{ netsim_action }} config file to switch (generated from {{ config_template }})"
   template:
     src: "{{ config_template }}"
     dest: /tmp/nvue_config.yaml
     mode: 0644
 
-- name: "execute on cumulus: 'nv config patch' for {{ config_module }} config"
+- block:
+  - name: "Start NVUE daemon"
+    command: systemctl start nvued
+
+  - name: "Wait for nvued to start"
+    service_facts:
+    register: svc
+    until: svc.ansible_facts.services['nvued.service'].state == 'running'
+    retries: 10
+    delay: 5
+
+  when: nvue_service_running is not defined
+
+- set_fact:
+    nvue_service_running: 1 
+
+- name: "execute on cumulus: 'nv config patch' for {{ netsim_action }} config"
   command: nv config patch /tmp/nvue_config.yaml
 
-- name: "execute on cumulus: 'nv config apply' for {{ config_module }} config"
+- name: "execute on cumulus: 'nv config apply' for {{ netsim_action }} config"
   command: nv config apply -y
+  tags: [ print_action, always ]

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -503,7 +503,16 @@ devices:
           lla: True
       ospf:
         unnumbered: True
-
+    clab:
+      mtu: 1500
+      runtime: docker
+      node:
+        kind: cvx
+      image: networkop/cx:5.0.1
+      group_vars:
+        ansible_connection: docker
+        ansible_user: root
+        
   srlinux:
     mgmt_if: mgmt0
     interface_name: ethernet-1/%d


### PR DESCRIPTION
Hi everyone,
it looks like the support of NVUE for CL 5.0.1 and containerlab is missing, so this patch enables the (small) missing part.
Unless I missed something, that works, `run-tests` looks good as well:
`Success: no issues found in 53 source files`

Let me know if something is needed for that part :)

Julien