### PR TITLE
Change python path to avoid Ansible issue

### DIFF
--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -409,7 +409,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
-        ansible_python_interpreter: /usr/local/bin/python3
+        ansible_python_interpreter: /usr/bin/python3
 
   vsrx:
     interface_name: ge-0/0/%d

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -409,7 +409,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
-        ansible_python_interpreter: /usr/bin/python3
+        ansible_python_interpreter: auto
 
   vsrx:
     interface_name: ge-0/0/%d
@@ -503,7 +503,17 @@ devices:
           lla: True
       ospf:
         unnumbered: True
-
+    clab:
+      mtu: 1500
+      runtime: docker
+      node:
+        kind: cvx
+      image: networkop/cx:5.0.1
+      group_vars:
+        ansible_connection: docker
+        ansible_user: root
+        ansible_python_interpreter: auto
+        
   srlinux:
     mgmt_if: mgmt0
     interface_name: ethernet-1/%d


### PR DESCRIPTION
Hi,
on some flavours, the python binary cannot be found in `/usr/local/bin/`
I experienced the same issue with some containers (for linux hosts) as well, which breaks Ansible at the task "template":
`Failed to get information on remote file (/tmp/config.sh): /bin/sh: 1: /usr/local/bin/python3: not found`

Even though, this is a packaging issue and not really a netsim issue, I wonder if we could proactively avoid some Ansible drama by using another $PATH with more better to succeed (or maybe implement a smart routine to check different $PATH).

Not sure this patch makes sense, but anyway, maybe someone will get a smarter solution :)

Julien