### PR TITLE
Change python path for nvue and linux

### DIFF
--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -409,7 +409,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
-        ansible_python_interpreter: /usr/local/bin/python3
+        ansible_python_interpreter: /usr/bin/python3
 
   vsrx:
     interface_name: ge-0/0/%d

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -409,7 +409,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
-        ansible_python_interpreter: /usr/bin/python3
+        ansible_python_interpreter: auto
 
   vsrx:
     interface_name: ge-0/0/%d
@@ -503,7 +503,17 @@ devices:
           lla: True
       ospf:
         unnumbered: True
-
+    clab:
+      mtu: 1500
+      runtime: docker
+      node:
+        kind: cvx
+      image: networkop/cx:5.0.1
+      group_vars:
+        ansible_connection: docker
+        ansible_user: root
+        ansible_python_interpreter: auto
+        
   srlinux:
     mgmt_if: mgmt0
     interface_name: ethernet-1/%d


### PR DESCRIPTION
- Pulled the last diff from dev
- Fix python interpreter path for `Linux`
- Add the config block for clab and `cumulus_nvue`
- Add python interpreter path for `cumulus_nvue` as well as the python 

Once the patch is committed, I will fix the minor detail in PR#231.
If you keep track of the contributors, you can add my full name: Julien Dhaille, instead of this github non-sense nickname :)