### PR TITLE
Throw a more explicit error on absence of module declaration

### DIFF
--- a/netsim/augment/topology.py
+++ b/netsim/augment/topology.py
@@ -83,7 +83,7 @@ def check_global_elements(topology: Box) -> None:
 
   for k in topology.keys():
     if not k in topo_elements:
-      common.error("Unknown top-level element %s" % k,category=common.IncorrectValue,module="topology")
+      common.error("Unknown top-level element %s, module not defined" % k,category=common.IncorrectValue,module="topology")
 #
 # Find virtualization provider, set provider and defaults.provider to that value
 #


### PR DESCRIPTION
Hi,
this is a minor change which removes any confusion and indicates clearly the absence of declaration.

Example:
```
vrfs:
  red:
  blue:

nodes:
  spine01:
    module: [ bgp]
```

IncorrectValue in topology: Unknown top-level element vrfs

Don't hesitate to remove/delete that PR if it is considered useless :)
And yes, I might be looking at more VRF support ;)