### PR TITLE
Fix: errors in Mikrotik ROS BGP RR handling (and VPNv4+OSPF)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 # Ignore everything that should be ignored ;)
 *.ignore.*
 x/
+publish-pypi.sh
 
 # Ignore Ansible retry and log files
 *.retry

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 Copyright (c) 2020-2022 Ivan Pepelnjak, Jeroen van Bemmel, Pete Crocker,
-Stefano Sasso, and others
+Stefano Sasso, Julien Dhaille, and others
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/docs/example/vrf-tutorial.md
+++ b/docs/example/vrf-tutorial.md
@@ -185,7 +185,7 @@ links:
 **Notes:**
 * The EBGP sessions between PE1 and PE2, and CB1 and CB2 will be configured within the VRF address family on PE1 and PE2.
 * A global IPv4/IPv6 IBGP session will be configured between PE1 and PE2.
-* The global IBGP session will not carry VPNv4 prefixes unless you add **mpls.vpn** (TBD) module to PE1 and PE2.
+* The global IBGP session will not carry VPNv4 prefixes unless you add **mpls.vpn** (see example below) module to PE1 and PE2.
 
 Behind the scenes, the VRF configuration module removes EBGP neighbors reachable through VRF interfaces from the global list of BGP neighbors on the PE-routers (so they won't be configured as part of the BGP routing process) and adds them to VRF data structure:
 
@@ -281,4 +281,54 @@ interface GigabitEthernet0/2
  ip ospf 100 area 0.0.0.0
  ip ospf network point-to-point
  ip ospf cost 10
+```
+
+## VPNv4 Prefixes
+If you want to carry VPNv4 (or VPNv6) prefixes, you have to enable **mpls.vpn** (and a MPLS label protocol, such as **mpls.ldp**).
+
+The following example expands the *EBGP Sessions with CE-Routers* configuration:
+```
+vrfs:
+  blue:
+
+module: [ vrf,ospf,bgp,mpls ]
+bgp.as: 65000
+
+nodes:
+  pe1:
+    mpls:
+      vpn: true
+      ldp: true
+  pe2:
+     mpls:
+       vpn: true
+       ldp: true
+  cb1:
+    module: [ bgp ]
+    bgp.as: 65101
+  cb2:
+    module: [ bgp ]
+    bgp.as: 65102
+  cb3:
+    module: [ bgp ]
+    bgp.as: 65103
+  cb4:
+    module: [ bgp ]
+    bgp.as: 65104
+
+links:
+- pe1:
+  pe2:
+- pe1: { vrf: blue }
+  cb1:
+- pe2: { vrf: blue }
+  cb1:
+- pe1: { vrf: blue }
+  cb2:
+- pe2: { vrf: blue }
+  cb2:
+- pe1: { vrf: blue }
+  cb3:
+- pe2: { vrf: blue }
+  cb4:
 ```

--- a/docs/module/mpls.md
+++ b/docs/module/mpls.md
@@ -21,11 +21,12 @@ The following table describes per-platform support of individual MPLS label dist
 
 ### Label Distribution Protocol (LDP)
 
-| Operating system  | LDP   | Exp.Null | IGP sync | Advertise<br>filter | CsC |
-| ------------------| :---: | :------: | :--: | :--: | :--: |
-| Arista EOS        |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
-| Cisco IOS         |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
-| Cisco IOS XE      |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
+| Operating system      | LDP   | Exp.Null | IGP sync | Advertise<br>filter | CsC |
+| ----------------------| :---: | :------: | :--: | :--: | :--: |
+| Arista EOS            |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
+| Cisco IOS             |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
+| Cisco IOS XE          |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
+| Mikrotik CHR RouterOS |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
 
 **Notes:**
 * LDP is enabled on all non-VRF intra-AS interfaces with IPv4 addresses.
@@ -33,11 +34,12 @@ The following table describes per-platform support of individual MPLS label dist
 
 ### BGP Labeled Unicast (BGP-LU)
 
-| Operating system  | BGP LU | Exp.Null | Disable<br>unlabeled |
-| ------------------| :----: | :------: | :------: |
-| Arista EOS        |   ✅   |    ❌     |    ✅    |
-| Cisco IOS         |   ✅   |    ✅    |    ❌     |
-| Cisco IOS XE      |   ✅   |    ✅    |    ❌     |
+| Operating system      | BGP LU | Exp.Null | Disable<br>unlabeled |
+| ----------------------| :----: | :------: | :------: |
+| Arista EOS            |   ✅   |    ❌   |    ✅    |
+| Cisco IOS             |   ✅   |    ✅   |    ❌    |
+| Cisco IOS XE          |   ✅   |    ✅   |    ❌    |
+| Mikrotik CHR RouterOS |   ❌   |    ❌   |    ❌    |
 
 **Notes**
 * Cisco IOS merges labeled and unlabeled BGP routes.
@@ -46,14 +48,16 @@ The following table describes per-platform support of individual MPLS label dist
 (mpls-l3vpn-supported-platforms)=
 ### BGP/MPLS L3VPN
 
-| Operating system  | VPNv4 | VPNv6 |
-| ------------------| :---: | :---: |
-| Arista EOS        |   ✅  |   ✅  |
-| Cisco IOS         |   ✅  |   ✅  |
-| Cisco IOS XE      |   ✅  |   ✅  |
+| Operating system      | VPNv4 | VPNv6 |
+| ----------------------| :---: | :---: |
+| Arista EOS            |   ✅  |   ✅  |
+| Cisco IOS             |   ✅  |   ✅  |
+| Cisco IOS XE          |   ✅  |   ✅  |
+| Mikrotik CHR RouterOS |   ✅  |   ❌  |
 
 **Notes**
 * VPNv4 and VPNv6 address families are enabled on IPv4 IBGP/EBGP sessions
+* On Mikrotik RouterOS BGP configuration/implementation, adding the VPNv4 AFI will completely overwrite the AFI supported list for the peer with "ip,vpnv4" (current template limitation). Given the general limitations of ROSv6 on IPv6, this should not be such a big problem.
 
 ## Configurable Global and Node Parameters
 

--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -18,9 +18,11 @@ VRFs are supported on these platforms:
 | Arista EOS            | ✅  | ✅  | ✅  |
 | Cisco IOS             | ✅  | ✅  | ✅  |
 | Cisco IOS XE          | ✅  | ✅  | ✅  |
+| Mikrotik CHR RouterOS | ✅  | ✅  | ✅  |
 
 **Notes:**
 * IS-IS cannot be run within a VRF, but the IS-IS configuration module is VRF-aware -- it will not try to configure IS-IS routing on VRF interfaces
+* On Mikrotik RouterOS BGP configuration/implementation, a BGP VRF instance cannot have the same Router ID of the default one. The current configuration template uses the IP Address of the last interface in the VRF as instance Router ID.
 
 ## Parameters
 
@@ -180,7 +182,7 @@ BGP, OSPF, and IS-IS configuration modules are VRF aware:
 
 Notes:
 
-* VRF-specific OSPF and BGP configuration is included in the VRF  configuration templates.
+* VRF-specific OSPF and BGP configuration is included in the VRF configuration templates.
 * Connected subnets are always redistributed into the BGP VRF address family.
 * If a node has **bgp.as** parameter and VRF-specific OSPF instance(s), the VRF configuration templates configure two-way redistribution between VRF-specific OSPF instances and BGP VRF address family.
 

--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -1,11 +1,28 @@
-- name: "copy the cumulus nvue yaml config file to switch for {{ config_module }} config"
+- name: "copy the cumulus nvue YAML {{ netsim_action }} config file to switch (generated from {{ config_template }})"
   template:
     src: "{{ config_template }}"
     dest: /tmp/nvue_config.yaml
     mode: 0644
 
-- name: "execute on cumulus: 'nv config patch' for {{ config_module }} config"
+- block:
+  - name: "Start NVUE daemon"
+    command: systemctl start nvued
+
+  - name: "Wait for nvued to start"
+    service_facts:
+    register: svc
+    until: svc.ansible_facts.services['nvued.service'].state == 'running'
+    retries: 10
+    delay: 5
+
+  when: nvue_service_running is not defined
+
+- set_fact:
+    nvue_service_running: 1 
+
+- name: "execute on cumulus: 'nv config patch' for {{ netsim_action }} config"
   command: nv config patch /tmp/nvue_config.yaml
 
-- name: "execute on cumulus: 'nv config apply' for {{ config_module }} config"
+- name: "execute on cumulus: 'nv config apply' for {{ netsim_action }} config"
   command: nv config apply -y
+  tags: [ print_action, always ]

--- a/netsim/ansible/templates/bgp/routeros.j2
+++ b/netsim/ansible/templates/bgp/routeros.j2
@@ -1,3 +1,4 @@
+{% import "routeros.macro.j2" as bgpcfg %}
 
 /routing bgp instance set 0 as={{ bgp.as }}
 
@@ -7,31 +8,7 @@
 
 {% for n in bgp.neighbors %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
-{%     set neigh_id = n[af]|replace('.', '_')|replace(':', '_') %}
-{%     set afi_list = [] %}
-{%     if n['ipv4'] is defined %}
-{{ afi_list.append('ip') }}
-{%     endif %}
-{%     if n['ipv6'] is defined %}
-{{ afi_list.append('ipv6') }}
-{%     endif %}
-
-/routing bgp peer add name={{ neigh_id }} remote-address={{ n[af] }} remote-as={{ n.as }} comment="{{ n.name }}" address-families={{ afi_list|join(',') }}
-{%   if n.type == 'ibgp' %}
-/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] update-source=loopback
-{%   endif %}
-
-{#
-#### NOTE - TODO
-# By Default, routeros has route-reflect=no.
-# THIS MUST BE SET ON THE RR Servers
-# and not on the clients, like it happens on other vendors
-#}
-
-{%    if bgp.next_hop_self is defined and bgp.next_hop_self %}
-/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] nexthop-choice=force-self
-{%    endif %}
-
+{{     bgpcfg.neighbor(n,n[af],'default') }}
 {%   endfor %}
 {% endfor %}
 
@@ -40,15 +17,15 @@
 {%   if bgp[af] is defined %}
 
 {%     if loopback[af] is defined and bgp.advertise_loopback %}
-/routing bgp network add network={{ loopback[af]|ipaddr('0') }}
+{{       bgpcfg.bgp_network(af,loopback[af]) }}
 {%     endif %}
 
 {%     for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined %}
-/routing bgp network add network={{ l[af]|ipaddr('0') }}
+{{       bgpcfg.bgp_network(af,l[af]) }}
 {%     endfor %}
 
 {%     for pfx in bgp.originate|default([]) if af == 'ipv4' %}
-/routing bgp network add network={{ pfx|ipaddr('0') }}
+{{       bgpcfg.bgp_network(af,pfx) }}
 {%     endfor %}
 
 {%   endif %}

--- a/netsim/ansible/templates/bgp/routeros.j2
+++ b/netsim/ansible/templates/bgp/routeros.j2
@@ -8,7 +8,7 @@
 
 {% for n in bgp.neighbors %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
-{{     bgpcfg.neighbor(n,n[af],'default') }}
+{{     bgpcfg.neighbor(n,n[af],bgp,'default') }}
 {%   endfor %}
 {% endfor %}
 

--- a/netsim/ansible/templates/bgp/routeros.macro.j2
+++ b/netsim/ansible/templates/bgp/routeros.macro.j2
@@ -1,0 +1,38 @@
+{#
+   BGP neighbor definition
+#}
+{% macro neighbor(n,ip,instance) %}
+
+{%   set neigh_id = ip|replace('.', '_')|replace(':', '_') %}
+{%   set afi_list = [] %}
+{%   if n['ipv4'] is defined %}
+{{ afi_list.append('ip') }}
+{%  endif %}
+{%   if n['ipv6'] is defined %}
+{{ afi_list.append('ipv6') }}
+{%   endif %}
+
+/routing bgp peer add name={{ neigh_id }} remote-address={{ ip }} remote-as={{ n.as }} \
+ comment="{{ n.name }}" instance={{ instance }} \
+  address-families={{ afi_list|join(',') }}
+
+{%   if n.type == 'ibgp' %}
+/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] update-source=loopback
+{%   endif %}
+
+{%    if bgp.rr|default('') and not n.rr|default('') %}
+/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] route-reflect=yes
+{%    endif %}
+
+{%    if bgp.next_hop_self is defined and bgp.next_hop_self %}
+/routing bgp peer set [/routing bgp peer find name={{ neigh_id }}] nexthop-choice=force-self
+{%    endif %}
+
+{%- endmacro %}
+
+{#
+   BGP network statement
+#}
+{% macro bgp_network(af,pfx) %}
+/routing bgp network add network={{ pfx|ipaddr('0') }}
+{%- endmacro %}

--- a/netsim/ansible/templates/bgp/routeros.macro.j2
+++ b/netsim/ansible/templates/bgp/routeros.macro.j2
@@ -1,7 +1,7 @@
 {#
    BGP neighbor definition
 #}
-{% macro neighbor(n,ip,instance) %}
+{% macro neighbor(n,ip,bgp,instance) %}
 
 {%   set neigh_id = ip|replace('.', '_')|replace(':', '_') %}
 {%   set afi_list = [] %}

--- a/netsim/ansible/templates/initial/routeros.j2
+++ b/netsim/ansible/templates/initial/routeros.j2
@@ -10,6 +10,10 @@
 /ipv6 address add interface=loopback address={{ loopback.ipv6 }}
 {% endif %}
 
+{% if vrfs is defined %}
+{% include 'routeros.vrf.j2' %}
+{% endif %}
+
 {% for l in interfaces|default([]) %}
 
 {% if l.name is defined %}

--- a/netsim/ansible/templates/initial/routeros.vrf.j2
+++ b/netsim/ansible/templates/initial/routeros.vrf.j2
@@ -1,0 +1,19 @@
+{% for vname,vdata in vrfs.items() %}
+
+{#
+  Create interface list for the vrf
+#}
+{% set vrf_if_list = [] %}
+{% for l in interfaces|default([]) %}
+{%   if l.vrf is defined %}
+{{ vrf_if_list.append(l.ifname) }}
+{%   endif %}
+{% endfor %}
+
+/ip route vrf add routing-mark={{ vname }} \
+ route-distinguisher={{ vdata.rd }} \
+ import-route-targets={{ vdata.import|join(',') }} \
+ export-route-targets={{ vdata.export|join(',') }} \
+ interfaces={{ vrf_if_list|join(',') }}
+
+{% endfor %}

--- a/netsim/ansible/templates/mpls/routeros.j2
+++ b/netsim/ansible/templates/mpls/routeros.j2
@@ -1,0 +1,6 @@
+{% if ldp is defined %}
+{%   include 'routeros.ldp.j2' +%}
+{% endif %}
+{% if mpls.vpn is defined %}
+{%   include 'routeros.mplsvpn.j2' +%}
+{% endif %}

--- a/netsim/ansible/templates/mpls/routeros.ldp.j2
+++ b/netsim/ansible/templates/mpls/routeros.ldp.j2
@@ -1,0 +1,14 @@
+
+/mpls ldp set enabled=yes lsr-id={{ ldp.router_id }}
+
+{% if 'ipv4' in loopback %}
+/mpls ldp set transport-address={{ loopback.ipv4|ipaddr('address') }}
+{% endif %}
+
+{% if ldp.explicit_null|default(False) %}
+/mpls ldp set use-explicit-null=yes
+{% endif %}
+
+{% for l in interfaces if ('ldp' in l) and not l.ldp.passive %}
+/mpls ldp interface add interface={{ l.ifname }}
+{% endfor %}

--- a/netsim/ansible/templates/mpls/routeros.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/routeros.mplsvpn.j2
@@ -1,0 +1,14 @@
+{#
+  Mikrotik is VPNv4 only, at least in ROS 6
+  NOTE: For now, this code assumes a BGP peer for the AFI ip is already present.
+  So it only adds the AFI vpnv4
+#}
+{% set af = 'ipv4' %}
+{% set vpnaf = 'vpnv4' %}
+{% if mpls.vpn[af] is defined %}
+
+{%   for n in bgp.neighbors if n[vpnaf] is defined %}
+/routing bgp peer set [find remote-address={{ n[vpnaf] }}] address-families=ip,vpnv4
+{%   endfor %}
+
+{% endif %}

--- a/netsim/ansible/templates/ospf/routeros.j2
+++ b/netsim/ansible/templates/ospf/routeros.j2
@@ -34,15 +34,15 @@
 
 /routing ospf interface add interface=loopback passive=yes
 {% if 'ipv4' in loopback %}
-/routing ospf network add area=[/routing ospf area find area-id={{ area }}] network={{ loopback.ipv4 }}
+/routing ospf network add area=[/routing ospf area find area-id={{ area }} and instance=default] network={{ loopback.ipv4 }}
 {% endif %}
 
-{% for l in interfaces|default([]) %}
+{% for l in interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
 {%   if "external" in l.role|default("") %}
 ## OSPF not configured on external interface {{ l.ifname }}
 {%   else %}
 
-/routing ospf network add area=[/routing ospf area find area-id={{ l.ospf.area|default(area) }}] network={{ l.ipv4 | ipaddr('subnet') }}
+/routing ospf network add area=[/routing ospf area find area-id={{ l.ospf.area|default(area) }} and instance=default] network={{ l.ipv4 | ipaddr('subnet') }}
 
 {% set ospf_intf_params=[] %}
 
@@ -51,7 +51,7 @@
 {%     endif %}
 
 {%     if l.ospf.cost is defined %}
-{{ ospf_intf_params.append('cost='+l.ospfcost) }}
+{{ ospf_intf_params.append('cost='+l.ospf.cost|string) }}
 {%     endif %}
 
 {%     if l.ospf.bfd|default(False) %}

--- a/netsim/ansible/templates/vrf/routeros.bgp-macro.j2
+++ b/netsim/ansible/templates/vrf/routeros.bgp-macro.j2
@@ -1,0 +1,1 @@
+../bgp/routeros.macro.j2

--- a/netsim/ansible/templates/vrf/routeros.bgp.j2
+++ b/netsim/ansible/templates/vrf/routeros.bgp.j2
@@ -23,12 +23,16 @@
 
 /routing bgp instance add router-id={{ vrf_router_id }} name={{ vname }} as={{ bgp.as }} routing-table={{ vname }} redistribute-other-bgp=yes
 
+{% if 'ospf' in vdata %}
+/routing bgp instance set [find name={{ vname }}] redistribute-ospf=yes
+{% endif %}
+
 {#
     And now the peers...
 #}
 {%   for n in vdata.bgp.neighbors|default([]) %}
 {%     for af in ['ipv4'] if n[af] is defined %}
-{{       bgpcfg.neighbor(n,n[af],vname) }}
+{{       bgpcfg.neighbor(n,n[af],vdata.bgp,vname) }}
 {%     endfor %}
 {%   endfor %}
 

--- a/netsim/ansible/templates/vrf/routeros.bgp.j2
+++ b/netsim/ansible/templates/vrf/routeros.bgp.j2
@@ -1,0 +1,35 @@
+{% import "routeros.bgp-macro.j2" as bgpcfg %}
+{% for vname,vdata in vrfs.items() %}
+{#
+    First of all, need to add the vrf to the default instance
+#}
+/routing bgp instance vrf add instance=default routing-mark={{ vname }} redistribute-connected=yes redistribute-other-bgp=yes
+{% if 'ospf' in vdata %}
+/routing bgp instance vrf set [find routing-mark={{ vname }}] redistribute-ospf=yes
+{% endif %}
+
+{#
+    Create a new BGP instance
+    NOTE: I had to do a bad workaround here.
+    Unfortunately, Mikrotik ROS does not like the fact that a BGP VRF instance can have the same Router ID of the main one.
+    The reported message is: "failure: instance with this RouterId already configured"
+    For that reason, as instance Router ID, the IP of the last interface in that VRF is used (can't easily use break in Jinja loops).
+#}
+{% set vrf_router_ids = [ '0.0.0.0' ] %}
+{% for l in interfaces|default([]) if l.vrf is defined and l.vrf == vname %}
+{{ vrf_router_ids.append(l.ipv4|ipaddr('address')) }}
+{% endfor %}
+{% set vrf_router_id = vrf_router_ids|last %}
+
+/routing bgp instance add router-id={{ vrf_router_id }} name={{ vname }} as={{ bgp.as }} routing-table={{ vname }} redistribute-other-bgp=yes
+
+{#
+    And now the peers...
+#}
+{%   for n in vdata.bgp.neighbors|default([]) %}
+{%     for af in ['ipv4'] if n[af] is defined %}
+{{       bgpcfg.neighbor(n,n[af],vname) }}
+{%     endfor %}
+{%   endfor %}
+
+{% endfor %}

--- a/netsim/ansible/templates/vrf/routeros.j2
+++ b/netsim/ansible/templates/vrf/routeros.j2
@@ -1,0 +1,6 @@
+{% if bgp.as is defined %}
+{% include 'routeros.bgp.j2' %}
+{% endif %}
+{% for vname,vdata in vrfs.items() if 'ospf' in vdata %}
+{%   include 'routeros.ospfv2-vrf.j2' %}
+{% endfor %}

--- a/netsim/ansible/templates/vrf/routeros.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/routeros.ospfv2-vrf.j2
@@ -1,0 +1,52 @@
+{% set KW_NETWORK_TYPE = {'point-to-point': 'point-to-point','point-to-multipoint': 'ptmp', 'non-broadcast': 'nbma','broadcast': 'broadcast' } %}
+{% set area = ospf.area|default("0.0.0.0") %}
+{#
+  Create new OSPF instance for the VRF
+#}
+/routing ospf instance add router-id={{ vdata.ospf.router_id|default(ospf.router_id) }} \
+  name={{ vname }} routing-table={{ vname }} redistribute-bgp=as-type-1
+
+{#
+  Create AREA list for the new instance
+#}
+{% set area_list = [] %}
+{% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
+{{ area_list.append(l.ospf.area) }}
+{% endfor %}
+
+{#
+  For each unique area, add to area configuration
+#}
+{% for a_def in area_list|unique %}
+/routing ospf area add name={{ vname }}-{{ a_def }} area-id={{ a_def }} instance={{ vname }}
+{% endfor %}
+
+
+{% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
+{%   if "external" in l.role|default("") %}
+## OSPF not configured on external interface {{ l.ifname }}
+{%   else %}
+
+/routing ospf network add area=[/routing ospf area find area-id={{ l.ospf.area|default(area) }} and instance={{ vname }}] network={{ l.ipv4 | ipaddr('subnet') }}
+
+{% set ospf_intf_params=[] %}
+
+{%     if l.ospf.network_type is defined %}
+{{ ospf_intf_params.append('network-type='+KW_NETWORK_TYPE[l.ospf.network_type]) }}
+{%     endif %}
+
+{%     if l.ospf.cost is defined %}
+{{ ospf_intf_params.append('cost='+l.ospf.cost|string) }}
+{%     endif %}
+
+{%     if l.ospf.bfd|default(False) %}
+{{ ospf_intf_params.append('use-bfd=yes') }}
+{%     endif %}
+
+{%     if ospf_intf_params|length > 0 %}
+/routing ospf interface add interface={{ l.ifname }} {{ ospf_intf_params|join(' ') }}
+{%     endif %}
+
+{%   endif %}
+
+{% endfor %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -401,6 +401,7 @@ devices:
       ansible_user: vagrant
       ansible_ssh_pass: vagrant
       docker_shell: sh
+      ansible_python_interpreter: auto
     clab:
       image: python:3.9-alpine
       mtu: 1500
@@ -409,7 +410,6 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
-        ansible_python_interpreter: /usr/local/bin/python3
 
   vsrx:
     interface_name: ge-0/0/%d
@@ -495,6 +495,7 @@ devices:
       ansible_ssh_pass: cumulus
       ansible_network_os: cumulus_nvue
       ansible_connection: paramiko
+      ansible_python_interpreter: auto
     features:
       initial:
         ipv4:
@@ -503,7 +504,16 @@ devices:
           lla: True
       ospf:
         unnumbered: True
-
+    clab:
+      mtu: 1500
+      runtime: docker
+      node:
+        kind: cvx
+      image: networkop/cx:5.0.1
+      group_vars:
+        ansible_connection: docker
+        ansible_user: root
+        
   srlinux:
     mgmt_if: mgmt0
     interface_name: ethernet-1/%d

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -111,7 +111,7 @@ evpn: # Enables the EVPN address family towards BGP peers
     global: [ use_ibgp ]
 
 vrf: # Basic VRF support
-  supported_on: [ eos, iosv, csr ]
+  supported_on: [ eos, iosv, csr, routeros ]
   as: 65000
   attributes:
     global: [ as ]
@@ -120,7 +120,7 @@ vrf: # Basic VRF support
     interface: str
 
 mpls: # LDP and BGP LU support
-  supported_on: [ eos, iosv, csr ]
+  supported_on: [ eos, iosv, csr, routeros ]
   config_after: [ ospf, isis, bgp ]
   transform_after: [ bgp ]
   ldp: True
@@ -621,6 +621,10 @@ devices:
       ansible_connection: network_cli
       ansible_user: admin
       ansible_ssh_pass: admin
+    features:
+      mpls:
+        ldp: True
+        vpn: True
 
 #
 # Output settings


### PR DESCRIPTION
@ipspace I **guess** a fix is also needed in:

1. https://github.com/ipspace/netsim-tools/blob/567160cc8a0e12863b9a376615e628c3c5de1a25/netsim/ansible/templates/vrf/eos.bgp.j2#L25
2. https://github.com/ipspace/netsim-tools/blob/567160cc8a0e12863b9a376615e628c3c5de1a25/netsim/ansible/templates/vrf/ios.bgp.j2#L13

to use *vdata.bgp* instead of *bgp*.