### PR TITLE
Support output in Graphite JSON format

### DIFF
--- a/docs/outputs/graphite.md
+++ b/docs/outputs/graphite.md
@@ -1,0 +1,89 @@
+# Graphite Topology Output Module
+
+Why use [Graphite](https://github.com/netreplica/graphite) only with ContainerLab? :-)
+
+*graphite* output module creates a JSON file that can be used to display the *netsim-tools* lab topology within Graphite.
+
+By default, the output is created as *graphite-default.json* file, which can be used directly from the Graphite container. Additionally, using the container *graphite:webssh2*, it is possible to launch SSH sessions towards the nodes directly from the browser.
+
+The Graphite container can be launched with:
+```
+docker run -d \
+ -v "$(pwd)/graphite-default.json":/var/www/localhost/htdocs/default/default.json \
+ -p 8080:80 \
+ --name graphite \
+ netreplica/graphite:webssh2
+```
+
+And you can access the Graphite WebGUI from: `http://<LOCAL_IP>:8080/graphite/`.
+
+## Modifying Graph Attributes
+
+The following attributes are allowed, at node level, or as **defaults** settings.
+* **graphite.icon**: Node Icon on the graph. Possible icon types are (from [Cisco DevNet NeXT UI API doc](https://developer.cisco.com/site/neXt/document/api-reference-manual/files/src_js_graphic_svg_Icons.js/#l11)):
+  * switch
+  * router
+  * wlc
+  * unknown
+  * server
+  * phone
+  * nexus5000
+  * ipphone
+  * host
+  * camera
+  * accesspoint
+  * groups
+  * cloud
+  * firewall
+  * hostgroup
+  * wirelesshost
+* **graphite.level**: Node Level on the graph (can be specified only at node level - defaults to `1`).
+
+## Topology Example
+
+```
+module: [ bgp, ospf ]
+bgp.as: 65000
+
+nodes:
+  a:
+  b:
+  c:
+  d:
+  rr:
+    bgp.rr: True
+    id: 1
+    graphite.icon: server
+  y:
+    bgp.as: 65100
+    module: [ bgp ]
+    graphite.level: 2
+  linux1:
+    module: []
+    device: linux
+    graphite.icon: host
+    graphite.level: 3
+  linux2:
+    module: []
+    device: linux
+    graphite.level: 3
+  linux3:
+    module: []
+    device: linux
+    graphite.level: 3
+
+links:
+- a-b
+- a-c
+- b-d
+- c-d
+- b-rr
+- d-rr
+- c-y
+- d-y
+- y-linux1
+- y:
+  linux2:
+  linux3:
+- y:
+```

--- a/docs/outputs/index.md
+++ b/docs/outputs/index.md
@@ -1,10 +1,10 @@
 # Output Formats
 
-**netlab create** command can call one or more output modules to create files that can be used with Vagrant, Ansible, containerlab, or graphviz. The output modules are specified with one or more `-o` parameters. When no `-o` parameter is specific, **netlab create** calls *provider* and *ansible* output modules.
+**netlab create** command can call one or more output modules to create files that can be used with Vagrant, Ansible, containerlab, graphviz or *graphite* topology. The output modules are specified with one or more `-o` parameters. When no `-o` parameter is specific, **netlab create** calls *provider* and *ansible* output modules.
 
 Each `-o` parameter specifies an output module, formatting modifiers, and output filename in the **format:modifiers=file(s)** format:
 
-* **format** is the desired output module. It can be one of *provider*, *ansible*, *graph*, *yaml* or *json*.
+* **format** is the desired output module. It can be one of *provider*, *ansible*, *graph*, *yaml*, *json* or *graphite*.
 * Some output modules use optional formatting modifiers -- you can specify Ansible inventory format, graph type, or parts of the transformed data structure that you want to see in YAML or JSON format
 * All output formats support optional destination file name. Default file name is either hard-coded in the module or specified in **defaults.outputs** part of lab topology.
 
@@ -19,4 +19,5 @@ The following output modules are included in **netsim-tools** distribution; you 
    graph.md
    yaml-or-json.md
    devices.md
+   graphite.md
 ```

--- a/netsim/outputs/graphite.py
+++ b/netsim/outputs/graphite.py
@@ -23,7 +23,7 @@ from . import _TopologyOutput
 
 DEFAULT_NODE_ICON = "router"
 
-def nodes_items(topology: Box):
+def nodes_items(topology: Box) -> list:
     r = []
     for name,n in topology.nodes.items():
         node_icon = DEFAULT_NODE_ICON
@@ -47,13 +47,13 @@ def nodes_items(topology: Box):
         )
     return r
 
-def get_lan_intf_name(topology: Box, node_name, bridge_name):
+def get_lan_intf_name(topology: Box, node_name, bridge_name) -> str:
     for intf in topology.nodes[node_name].interfaces:
         if intf.get('bridge','') == bridge_name:
             return intf.ifname
     return "<unknown>"
 
-def links_items(topology: Box):
+def links_items(topology: Box) -> list:
     r = []
     for l in topology.links:
         # P2P Links

--- a/netsim/outputs/graphite.py
+++ b/netsim/outputs/graphite.py
@@ -1,0 +1,102 @@
+# Why use Graphite (https://github.com/netreplica/graphite) only with ContainerLab? :-)
+#
+# With this output module it would be possible to export a topology file to be used within Graphite.
+# 
+# Graphite container can be launched with:
+#
+# docker run -d \
+#  -v "$(pwd)/graphite-default.json":/var/www/localhost/htdocs/default/default.json \
+#  -p 8080:80 \
+#  --name graphite \
+#  netreplica/graphite:webssh2
+#
+
+from array import array
+import typing
+
+import json
+import os
+from box import Box
+
+from .. import common
+from . import _TopologyOutput
+
+DEFAULT_NODE_ICON = "router"
+
+def nodes_items(topology: Box):
+    r = []
+    for name,n in topology.nodes.items():
+        node_icon = DEFAULT_NODE_ICON
+        if n.device == 'linux':
+            node_icon = 'server'
+        node_group = "tier-1"
+        node_as = n.get('bgp', {}).get('as')
+        if node_as:
+            node_group = "as{}".format(node_as)
+        r.append(
+            {
+                'name': name,
+                'kind': n.device,
+                "ipv4_address": n.mgmt.ipv4,
+                "group": node_group,
+                "labels": {
+                    "graph-level": 1,
+                    "graph-icon": node_icon,
+                },
+            }
+        )
+    return r
+
+def get_lan_intf_name(topology: Box, node_name, bridge_name):
+    for intf in topology.nodes[node_name].interfaces:
+        if intf.get('bridge','') == bridge_name:
+            return intf.ifname
+    return "<unknown>"
+
+def links_items(topology: Box):
+    r = []
+    for l in topology.links:
+        # P2P Links
+        if l.type == "p2p":
+            r.append(
+                {
+                    "source": l.left.node,
+                    "source_endpoint": l.left.ifname,
+                    "target": l.right.node,
+                    "target_endpoint": l.right.ifname
+                }
+            )
+        # For now threat LAN Links like a P2P, using only the first two interfaces 
+        # TODO: verify additional behaviour
+        elif l.type == "lan":
+            if l.node_count > 1:
+                r.append(
+                    {
+                        "source": l.interfaces[0].node,
+                        "source_endpoint": get_lan_intf_name(topology, l.interfaces[0].node, l.bridge),
+                        "target": l.interfaces[1].node,
+                        "target_endpoint": get_lan_intf_name(topology, l.interfaces[1].node, l.bridge),
+                    }
+                )
+    return r
+
+class Graphite(_TopologyOutput):
+
+  def write(self, topology: Box) -> None:
+    outfile = self.settings.filename or 'graphite-default.json'
+
+    graphite_json = {
+        'nodes': nodes_items(topology),
+        'links': links_items(topology),
+    }
+
+    output = common.open_output_file(outfile)
+
+    output.write(json.dumps(graphite_json, indent=2,sort_keys=True))
+    output.write("\n")
+
+    if outfile != '-':
+      common.close_output_file(output)
+      print("Created Graphite topology file in %s" % outfile)
+    else:
+      output.write("\n")

--- a/netsim/outputs/graphite.py
+++ b/netsim/outputs/graphite.py
@@ -47,7 +47,7 @@ def nodes_items(topology: Box) -> list:
         )
     return r
 
-def get_lan_intf_name(topology: Box, node_name, bridge_name) -> str:
+def get_lan_intf_name(topology: Box, node_name: str, bridge_name: str) -> str:
     for intf in topology.nodes[node_name].interfaces:
         if intf.get('bridge','') == bridge_name:
             return intf.ifname

--- a/netsim/outputs/graphite.py
+++ b/netsim/outputs/graphite.py
@@ -19,6 +19,7 @@ import os
 from box import Box
 
 from .. import common
+from .. import data
 from . import _TopologyOutput
 
 DEFAULT_NODE_ICON = "router"
@@ -26,9 +27,9 @@ DEFAULT_NODE_ICON = "router"
 def nodes_items(topology: Box) -> list:
     r = []
     for name,n in topology.nodes.items():
-        node_icon = DEFAULT_NODE_ICON
-        if n.device == 'linux':
-            node_icon = 'server'
+        node_icon = ( data.get_from_box(n,'graphite.icon') or 
+            data.get_from_box(topology,f'defaults.devices.{n.device}.graphite.icon') or 
+            DEFAULT_NODE_ICON )
         node_group = "tier-1"
         node_as = n.get('bgp', {}).get('as')
         if node_as:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -241,6 +241,7 @@ devices:
         ldp: True
         bgp: True
         vpn: True
+    graphite.icon: router
 
   csr:
     interface_name: GigabitEthernet%d
@@ -278,6 +279,7 @@ devices:
       create:
         virt-install --connect=qemu:///system --name=vm_box --os-type=linux --os-variant=rhel4 --arch=x86_64 --cpu host --vcpus=1 --hvm
           --ram=4096 --disk path=vm.qcow2,bus=ide,format=qcow2 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+    graphite.icon: router
 
   nxos:
     interface_name: Ethernet1/%d
@@ -306,6 +308,7 @@ devices:
     libvirt:
       create_template: nxos.xml.j2
       image: cisco/nexus9300v
+    graphite.icon: nexus5000
 
   eos:
     interface_name: Ethernet%d
@@ -355,6 +358,7 @@ devices:
       create: |
         virt-install --connect=qemu:///system --name=vm_box --os-type=linux --arch=x86_64 --cpu host --vcpus=2 --hvm
           --ram=2048 --disk path=vm.qcow2,bus=ide,format=qcow2 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+    graphite.icon: switch
 
   fortios:
     interface_name: port%d
@@ -374,6 +378,7 @@ devices:
       ansible_httpapi_validate_certs: no
       ansible_httpapi_port: 80
       netsim_console_connection: ssh
+    graphite.icon: firewall
 
   frr:
     interface_name: eth%d
@@ -386,6 +391,7 @@ devices:
       mtu: 1500
       node:
         kind: linux
+    graphite.icon: router
 
   linux:
     interface_name: eth%d
@@ -410,6 +416,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
+    graphite.icon: server
 
   vsrx:
     interface_name: ge-0/0/%d
@@ -442,6 +449,7 @@ devices:
         virt-install --connect=qemu:///system --name=vm_box --os-variant=freebsd10 --arch=x86_64 --cpu host --vcpus=2 --hvm
           --ram=4096 --disk path=vm.qcow2,bus=ide,format=qcow2 --disk path=bootstrap.iso,device=cdrom,bus=ide
           --boot hd --network=network:vagrant-libvirt,model=virtio --graphics none --import
+    graphite.icon: firewall
 
   arcos:
     interface_name: swp%d
@@ -452,6 +460,7 @@ devices:
       ansible_user: root
       ansible_ssh_pass: arcos
       ansible_network_os: arcos
+    graphite.icon: router
 
   cumulus:
     interface_name: swp%d
@@ -482,6 +491,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
+    graphite.icon: switch
 
   cumulus_nvue:
     interface_name: swp%d
@@ -513,6 +523,7 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
+    graphite.icon: switch
         
   srlinux:
     mgmt_if: mgmt0
@@ -553,6 +564,7 @@ devices:
           ipv4: False
           ipv6: True
           network: False
+    graphite.icon: router
 
   sros:
     mgmt_if: A/1
@@ -598,6 +610,7 @@ devices:
         name: eth%d
       group_vars:
         sros_grpc_port: 57400
+    graphite.icon: router
 
   vyos:
     interface_name: eth%d
@@ -609,6 +622,7 @@ devices:
       ansible_connection: paramiko
       ansible_user: vagrant
       ansible_ssh_pass: vagrant
+  graphite.icon: router
 
   routeros:
     interface_name: ether%d
@@ -625,6 +639,7 @@ devices:
       mpls:
         ldp: True
         vpn: True
+    graphite.icon: router
 
 #
 # Output settings


### PR DESCRIPTION
Why use Graphite (https://github.com/netreplica/graphite) only with ContainerLab? :-)

With this output module it would be possible to export a topology file to be used within Graphite.
 
Graphite container can be launched with:

```
docker run -d \
 -v "$(pwd)/graphite-default.json":/var/www/localhost/htdocs/default/default.json \
 -p 8080:80 \
 --name graphite \
 netreplica/graphite:webssh2
```
Result example: 
![image](https://user-images.githubusercontent.com/852093/162444687-eef8b6c7-ad1d-4335-9d16-8827831fe330.png)

Additionally, with the *graphite:webssh2*, SSH can be launched from the browser as well ;)

![image](https://user-images.githubusercontent.com/852093/162444858-864a0798-8db3-49b7-a57d-56d368a9f376.png)

