### PR TITLE
Mikrotik: add comment on IP Addresses

### DIFF
--- a/netsim/ansible/templates/initial/routeros.j2
+++ b/netsim/ansible/templates/initial/routeros.j2
@@ -26,8 +26,15 @@
 /interface ethernet set mtu={{ l.mtu }} {{ l.ifname }}
 {% endif %}
 
+{#
+# Add same interface comment also to the IP Address, for better troubleshooting
+# Only supported in IPv4, for now.
+#}
 {% if 'ipv4' in l %}
 /ip address add interface={{ l.ifname }} address={{ l.ipv4 }}
+{%   if l.name is defined %}
+/ip address set [find where interface={{ l.ifname }}] comment="{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}"
+{%   endif %}
 {% endif %}
 {% if 'ipv6' in l %}
 /ipv6 address add interface={{ l.ifname }} address={{ l.ipv6 }}


### PR DESCRIPTION
Mikrotik: add comment on IP Addresses, for better troubleshooting.
Works only on IPv4, for now. On IPv6 there seems to be match problems in the *find/where* statement.