### PR TITLE
Support for Dell OS10

### DIFF
--- a/docs/labs/dellos10.md
+++ b/docs/labs/dellos10.md
@@ -1,0 +1,52 @@
+# Building a Dell OS10 Vagrant Libvirt Box
+
+Dell OS10 is supported by the **netlab libvirt package** command.
+
+```{warning}
+Dell provides the OS10 Virtual image as a set of vmdk and gns3a files to be used within GNS3, and only for the main release track (i.e., 10.5.2.0). The following procedure will "convert" the required files for using them with Vagrant, and also allows to inject a specific build release into the image (the image is based on a ONIE installer).
+```
+
+To prepare for the build:
+
+* Create an empty directory on a Ubuntu machine with *libvirt* and *Vagrant*.
+* QEMU Covert these 3 files:
+  * OS10-Disk-1.0.0.vmdk
+  * OS10-Installer-`<VERSION>`.vmdk
+  * OS10-platform-S4128F-`<VERSION>`.vmdk
+```
+qemu-img convert -O qcow2 /tmp/OS10-Disk-1.0.0.vmdk OS10-Disk-1.qcow2
+qemu-img convert -O qcow2 /tmp/OS10-Installer-10.5.2.0.229.vmdk hdb_OS10-installer.qcow2
+qemu-img convert -O qcow2 /tmp/OS10-platform-S4128F-10.5.2.0.229.vmdk hdc_OS10-platform-S4128F.qcow2
+```
+* Copy the updated Dell OS10 upgrade package (*.bin*) inside the *hdb_OS10-installer.qcow2* disk image:
+```
+modprobe nbd max_part=8
+qemu-nbd --connect=/dev/nbd0 ./hdb_OS10-installer.qcow2
+
+mount /dev/nbd0p1 /mnt/somepoint/
+
+cd /mnt/somepoint/
+cp /tmp/PKGS_OS10-Enterprise-10.5.3.4.108buster-installer-x86_64.bin os10.bin
+chmod 777 os10.bin
+md5sum os10.bin | awk '{print $1}' > image.txt
+
+cd
+umount /mnt/somepoint/
+qemu-nbd --disconnect /dev/nbd0
+```
+
+To build a Dell OS10 box based on the above install image:
+
+* Execute **netlab libvirt package dellos10 OS10-Disk-1.qcow2** and follow the instructions
+
+## Initial Device Configuration
+
+During the box-building process you'll have to copy-paste initial device configuration. **netlab libvirt config dellos10** command displays the build recipe:
+
+```{eval-rst}
+.. include:: dellos10.txt
+   :literal:
+```
+
+
+

--- a/docs/labs/dellos10.txt
+++ b/docs/labs/dellos10.txt
@@ -1,0 +1,1 @@
+../../netsim/install/libvirt/dellos10.txt

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -14,6 +14,7 @@ You have to use the following box names when installing or building the Vagrant 
 | Juniper vSRX 3.0       | juniper/vsrx3               |
 | VyOS                   | vyos/vyos                   |
 | Mikrotik CHR RouterOS  | mikrotik/chr                |
+| Dell OS10              | dell/os10                   |
 
 The following Vagrant boxes are automatically downloaded from Vagrant Cloud when you're using them for the first time in your lab topology:
 
@@ -33,6 +34,7 @@ The following Vagrant boxes are automatically downloaded from Vagrant Cloud when
 * [Juniper vSRX 3.0](vsrx.md)
 * [Mikrotik RouterOS](http://stefano.dscnet.org/a/mikrotik_vagrant/) by [Stefano Sasso](http://stefano.dscnet.org)
 * [VyOS](https://github.com/ssasso/packer-vyos-vagrant) by [Stefano Sasso](http://stefano.dscnet.org)
+* [Dell OS10](dellos10.md)
 
 **Notes:**
 

--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -15,6 +15,7 @@ BFD is supported on these platforms:
 | Nokia SR Linux        | ✅  | ✅  | ✅  |
 | Nokia SR OS           | ✅  | ✅  | ✅  |
 | VyOS                  |  ❌  | ✅  | ✅  |
+| Dell OS10             |  ❌  | ✅  | ❌  |
 
 **Notes:**
 * Junos configuration template configures BFD timers within routing protocol configuration, not in individual interfaces

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -42,6 +42,7 @@ The following table describes per-platform support of individual router-level OS
 | Nokia SR Linux           |   ✅  |            ✅          |   ❌   |  ✅  |
 | Nokia SR OS              |   ✅  |            ✅          |   ❌   |  ✅  |
 | VyOS                     |   ✅  |            ✅          |   ✅   |  ✅  |
+| Dell OS10                |   ✅  |            ✅          |   ✅   |  ✅  |
 
 **Notes:**
 * Fortinet implementation of OSPF configuration module does not implement per-interface OSPF areas. All interfaces belong to the OSPF area defined in the node data.
@@ -64,9 +65,10 @@ The following table documents the interface-level OSPF features:
 | Nokia SR Linux           |   ✅  |         ✅        |             ❌            |            ✅           |
 | Nokia SR OS              |   ✅  |         ✅        |             ✅            |            ✅           |
 | VyOS                     |   ✅  |         ✅        |             ❌            |            ✅           |
+| Dell OS10                |   ✅  |         ✅        |             ❌            |            ✅           |
 
 Notes:
-* Arista EOS, Cisco Nexus OS, and SR Linux support point-to-point and broadcast network types. Other network types will not be configured.
+* Arista EOS, Cisco Nexus OS, SR Linux and Dell OS10 support point-to-point and broadcast network types. Other network types will not be configured.
 * SR OS supports point-to-point, broadcast and non-broadcast network types. Point-to-multipoint network type will not be configured.
 * Cisco IOSv (release 15.x) does not support unnumbered IPv4 interfaces
 * FRR does not support passive interfaces with OSPFv3

--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -19,6 +19,7 @@ VRFs are supported on these platforms:
 | Cisco IOS             | ✅  | ✅  | ✅  |
 | Cisco IOS XE          | ✅  | ✅  | ✅  |
 | Mikrotik CHR RouterOS | ✅  | ✅  | ✅  |
+| Dell OS10             | ✅  | ✅  | ✅  |
 
 **Notes:**
 * IS-IS cannot be run within a VRF, but the IS-IS configuration module is VRF-aware -- it will not try to configure IS-IS routing on VRF interfaces

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -18,6 +18,7 @@ The following virtual network devices are supported by *netsim-tools*:
 | Nokia SR Linux                            | srlinux            |
 | Nokia SR OS [❗](caveats.html#nokia-sr-os) | sros               |
 | VyOS                                      | vyos               |
+| Dell OS10                                 | dellos10           |
 
 **Notes:**
 
@@ -69,6 +70,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | Nokia SR Linux                                     |          ❌           |              ❌               |            ✅             |
 | Nokia SR OS                                        |          ❌           |              ❌               |            ✅             |
 | VyOS                                               |          ✅           |              ❌               |            ❌             |
+| Dell OS10                                          |          ✅           |              ❌               |            ❌             |
 
 Configuration files for Virtualbox and KVM/libvirt environments specify the number of virtual CPUs and memory allocated to individual network devices. These are the default values; you can change them with [node parameters](nodes.md#node-attributes).
 
@@ -85,6 +87,7 @@ Configuration files for Virtualbox and KVM/libvirt environments specify the numb
 | Juniper vSRX 3.0           | vsrx               |    2 |   4096 | 
 | Mikrotik CHR RouterOS      | routeros           |    1 |    256 |
 | VyOS                       | vyos               |    2 |   1024 |
+| Dell OS10                  | vyos               |    2 |   2048 |
 
 ## Configuration Deployments
 
@@ -104,6 +107,7 @@ Ansible playbooks included with **netsim-tools** can deploy and collect device c
 | Nokia SR Linux        |          ✅           |           ❌           |
 | Nokia SR OS           |          ✅           |           ❌           |
 | VyOS                  |          ✅           |           ✅           |
+| Dell OS10             |          ✅           |           ✅           |
 
 ## Initial Device Configurations
 
@@ -124,6 +128,7 @@ The following system-wide features are configured on supported network operating
 | Nokia SR OS           |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
 | VyOS                  |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
 | Mikrotik CHR RouterOS |    ✅     |     ✅      | ✅[❗](caveats.html#mikrotik-chr-routeros) |             ✅              |             ✅              |
+| Dell OS10             |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
 
 The following interface parameters are configured on supported network operating systems as part of initial device configuration:
 
@@ -142,6 +147,7 @@ The following interface parameters are configured on supported network operating
 | Nokia SR Linux        |            ✅              |            ❌            | ❌ |
 | Nokia SR OS           |            ✅              |            ❌            | ❌ |
 | VyOS                  |            ✅              |            ❌            | ✅ |
+| Dell OS10             |            ✅              |            ❌            | ✅ |
 
 
 The following interface addresses are supported on various platforms:
@@ -161,6 +167,7 @@ The following interface addresses are supported on various platforms:
 | Nokia SR Linux        |          ✅          |          ✅          |             ❌              |
 | Nokia SR OS           |          ✅          |          ✅          |             ✅              |
 | VyOS                  |          ✅          |          ✅          |             ❌              |
+| Dell OS10             |          ✅          |          ✅          |             ❌              |
 
 ## Supported Configuration Modules
 
@@ -182,6 +189,7 @@ Individual **netsim-tools** [configuration modules](module-reference.md) are sup
 | Nokia SR Linux        | ✅   |  ✅   |   ❌   | ✅  | ✅  |    ✅   |
 | Nokia SR OS           | ✅   |  ✅   |   ❌   | ✅  | ✅  |    ✅   |
 | VyOS                  | ✅   |   ❌   |   ❌   | ✅  | ✅  |    ❌    |
+| Dell OS10             | ✅   |   ❌   |   ❌   | ✅  | ✅  |    ❌    |
 
 ## IPv6 Support
 
@@ -203,3 +211,4 @@ Core functionality of *netsim-tools* and all multi-protocol routing protocol con
 | Nokia SR Linux        |          ✅          |   ❌    |    ❌     |         ❌          |        ✅         |    ✅    |
 | Nokia SR OS           |          ✅          |   ❌    |    ❌     |         ❌          |        ✅         |    ✅    |
 | VyOS                  |          ✅          |   ❌    |    ❌     |         ❌          |        ✅         |    ❌    |
+| Dell OS10             |          ✅          |   ✅    |    ❌     |         ❌          |        ✅         |    ❌    |

--- a/netsim/ansible/tasks/deploy-config/dellos10.yml
+++ b/netsim/ansible/tasks/deploy-config/dellos10.yml
@@ -1,0 +1,12 @@
+- wait_for_connection:
+    timeout: 60
+  when: |
+    netlab_provider == 'clab' and ansible_connection == 'network_cli'
+
+- name: "dellos10_config: deploying {{ netsim_action }} from {{ config_template }}"
+  dellemc.os10.os10_config:
+    match: "none"
+    src: "{{ lookup('template', config_template) }}"
+    save: "yes"
+  tags: [ print_action, always ]
+  register: os10_output

--- a/netsim/ansible/tasks/fetch-config/dellos10.yml
+++ b/netsim/ansible/tasks/fetch-config/dellos10.yml
@@ -1,0 +1,5 @@
+# fetch Dell OS10 configuration using os10_facts module
+#
+---
+- dellemc.os10.os10_facts:
+    gather_subset: config

--- a/netsim/ansible/templates/bgp/dellos10.j2
+++ b/netsim/ansible/templates/bgp/dellos10.j2
@@ -1,0 +1,43 @@
+{% import "dellos10.macro.j2" as bgpcfg %}
+!
+router bgp {{ bgp.as }}
+  log-neighbor-changes
+
+{% if bgp.router_id|ipv4 %}
+  router-id {{ bgp.router_id }}
+{% endif %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
+  cluster-id {{ bgp.rr_cluster_id }}
+{% endif %}
+{% if bgp.rr|default('') %}
+  client-to-client reflection
+{% endif %}
+{% for n in bgp.neighbors %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+{{     bgpcfg.neighbor(n,n[af],bgp) }}
+{%   endfor %}
+{% endfor %}
+!
+{% for af in ['ipv4','ipv6'] %}
+{%   if bgp[af] is defined %}
+!
+ address-family {{ af }} unicast
+!
+{%     if loopback[af] is defined and bgp.advertise_loopback %}
+  network {{ loopback[af]|ipaddr('0') }}
+{%     endif %}
+!
+{%     for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined %}
+  network {{ l[af]|ipaddr('0') }}
+{%     endfor %}
+!
+{%     for pfx in bgp.originate|default([]) if af == 'ipv4' %}
+  network {{ pfx|ipaddr('0') }}
+{%     endfor %}
+!
+{%   endif %}
+{% endfor %}
+!
+{% for pfx in bgp.originate|default([]) %}
+ip route {{ pfx|ipaddr('0') }} interface null 0
+{% endfor %}

--- a/netsim/ansible/templates/bgp/dellos10.macro.j2
+++ b/netsim/ansible/templates/bgp/dellos10.macro.j2
@@ -1,0 +1,52 @@
+{#
+  Define a BGP neighbor
+#}
+{% macro neighbor(n,ip,bgp) %}
+!
+  neighbor {{ ip }}
+    remote-as {{ n.as }}
+    description "{{ n.name }}"
+{%     if n.type == 'ibgp' %}
+    update-source loopback0
+{%       if bgp.next_hop_self is defined and bgp.next_hop_self %}
+{#
+  In Dell OS10, next-hop-self is configured under AF
+#}
+{%         for af in ['ipv4','ipv6'] if bgp[af] is defined %}
+!
+ address-family {{ af }} unicast
+   next-hop-self
+ exit
+{%         endfor %}
+
+{%       endif %}
+{%       if bgp.rr|default('') and not n.rr|default('') %}
+    route-reflector-client
+{%       endif %}
+{%       if bgp.community.ibgp|default([]) %}
+{%         if "extended" in bgp.community.ibgp|default([]) %}
+    send-community extended
+{%         else %}
+    send-community standard
+{%         endif %}
+{%       endif %}
+{%   else %}
+{%       if bgp.community.ebgp|default([]) %}
+{%         if "extended" in bgp.community.ebgp|default([]) %}
+    send-community extended
+{%         else %}
+    send-community standard
+{%         endif %}
+{%       endif %}
+{%     endif %}
+
+{% for af in ['ipv4','ipv6'] if bgp[af] is defined %}
+!
+ address-family {{ af }} unicast
+   activate
+ exit
+{% endfor %}
+  
+  no shutdown
+  exit
+{%- endmacro %}

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -1,0 +1,68 @@
+hostname {{ inventory_hostname.replace("_","-") }}
+!
+lldp enable
+!
+{% if vrfs is defined %}
+{% include 'dellos10.vrf.j2' %}
+{% endif %}
+!
+{% for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) and v.loopback.ipv4 is defined %}
+ip host {{ k|replace('_','') }} {{ v.loopback.ipv4|ipaddr('address') }}
+{% endfor %}
+!
+{% if mtu is defined %}
+!
+default mtu {{ mtu }}
+{% endif %}
+!
+interface loopback0
+{% if 'ipv4' in loopback %}
+ ip address {{ loopback.ipv4 }}
+{% endif %}
+{% if 'ipv6' in loopback %}
+ ipv6 address {{ loopback.ipv6 }}
+{% endif %}
+!
+interface {{ mgmt.ifname|default('mgmt1/1/1') }}
+ no lldp transmit
+ no lldp receive
+!
+{% for l in interfaces|default([]) %}
+interface {{ l.ifname }}
+ no shutdown
+ no switchport
+{% if l.vrf is defined %}
+ ip vrf forwarding {{ l.vrf }}
+{% endif %}
+{% if l.mtu is defined %}
+ mtu {{ l.mtu }}
+{% endif %}
+{% if l.name is defined %}
+ description "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}"
+{% elif l.type|default("") == "stub" %}
+ description "Stub interface"
+{% endif %}
+{#
+    Set interface IPv4 addresses
+#}
+{% if 'ipv4' in l %}
+{%   if l.ipv4|ipv4 %}
+ ip address {{ l.ipv4 }}
+{%   else %}
+! Invalid IPv4 address {{ l.ipv4 }}
+{%   endif %}
+{% endif %}
+{#
+    Set interface IPv6 addresses
+#}
+{% if 'ipv6' in l %}
+{%   if l.ipv6 == True %}
+ ipv6 enable
+{%   elif l.ipv6|ipv6 %}
+ ipv6 address {{ l.ipv6 }}
+{%   else %}
+! Invalid IPv6 address {{ l.ipv6 }}
+{%   endif %}
+{% endif %}
+!
+{% endfor %}

--- a/netsim/ansible/templates/initial/dellos10.vrf.j2
+++ b/netsim/ansible/templates/initial/dellos10.vrf.j2
@@ -1,0 +1,24 @@
+{% for vname,vdata in vrfs.items() %}
+ip vrf {{ vname }}
+!
+{% if 'ipv4' in vdata.af %}
+! ip route-import|export xxx
+{%   for rt in vdata.import %}
+ ip route-import {{ rt }}
+{%   endfor %}
+{%   for rt in vdata.export %}
+ ip route-export {{ rt }}
+{%   endfor %}
+!
+{% endif %}
+{% if 'ipv6' in vdata.af %}
+! ipv6 route-import|export xxx
+{%   for rt in vdata.import %}
+ ipv6 route-import {{ rt }}
+{%   endfor %}
+{%   for rt in vdata.export %}
+ ipv6 route-export {{ rt }}
+{%   endfor %}
+!
+{% endif %}
+{% endfor %}

--- a/netsim/ansible/templates/ospf/dellos10.j2
+++ b/netsim/ansible/templates/ospf/dellos10.j2
@@ -1,0 +1,7 @@
+{% set pid = ospf.process|default(1) %}
+{% if ospf.af.ipv4 is defined %}
+{% include 'dellos10.ospfv2.j2' %}
+{% endif %}
+{% if ospf.af.ipv6 is defined %}
+{% include 'dellos10.ospfv3.j2' %}
+{% endif %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
@@ -1,0 +1,31 @@
+router ospf {{ pid }}
+{% if ospf.router_id|ipv4 %}
+ router-id {{ ospf.router_id }}
+{% endif %}
+{% if ospf.reference_bandwidth is defined %}
+ auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
+{% endif %}
+
+!
+interface loopback0
+ ip ospf {{ pid }} area {{ ospf.area }}
+ ip ospf passive
+!
+{% for l in interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
+interface {{ l.ifname }}
+! {{ l.name|default("") }}
+ ip ospf {{ pid }} area {{ l.ospf.area }}
+{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
+ ip ospf network {{ l.ospf.network_type }}
+{%   endif %}
+{%   if l.ospf.cost is defined %}
+ ip ospf cost {{ l.ospf.cost }}
+{%   endif %}
+{%   if l.ospf.bfd|default(False) %}
+ ip ospf bfd all-neighbors
+{%   endif %}
+{%   if l.ospf.passive|default(False) %}
+ ip ospf passive
+{%   endif %}
+!
+{% endfor %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
@@ -1,0 +1,30 @@
+router ospfv3 {{ pid }}
+ router-id {{ ospf.router_id }}
+{% if ospf.reference_bandwidth is defined %}
+ auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
+{% endif %}
+
+!
+{% if 'ipv6' in loopback %}
+interface loopback0
+ ipv6 ospf {{ pid }} area {{ ospf.area }}
+{% endif %}
+!
+{% for l in interfaces|default([]) if 'ospf' in l and 'ipv6' in l %}
+interface {{ l.ifname }}
+! {{ l.name|default("") }}
+ ipv6 ospf {{ pid }} area {{ l.ospf.area }}
+{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
+ ipv6 ospf network {{ l.ospf.network_type }}
+{%   endif %}
+{%   if l.ospf.cost is defined %}
+ ipv6 ospf cost {{ l.ospf.cost }}
+{%   endif %}
+{%   if l.ospf.bfd|default(False) %}
+ ipv6 ospf bfd all-neighbors
+{%   endif %}
+{%   if l.ospf.passive|default(False) %}
+ ipv6 ospf passive
+{%   endif %}
+!
+{% endfor %}

--- a/netsim/ansible/templates/vrf/dellos10.bgp-macro.j2
+++ b/netsim/ansible/templates/vrf/dellos10.bgp-macro.j2
@@ -1,0 +1,1 @@
+../bgp/dellos10.macro.j2

--- a/netsim/ansible/templates/vrf/dellos10.bgp.j2
+++ b/netsim/ansible/templates/vrf/dellos10.bgp.j2
@@ -1,0 +1,24 @@
+{% import "dellos10.bgp-macro.j2" as bgpcfg %}
+!
+router bgp {{ bgp.as }}
+{% for vname,vdata in vrfs.items() %}
+!
+ vrf {{ vname }}
+  router-id {{ bgp.router_id }}
+
+{%   for n in vdata.bgp.neighbors|default([]) %}
+{%     for af in ['ipv4','ipv6'] if n[af] is defined %}
+{{       bgpcfg.neighbor(n,n[af],bgp) }}
+{%     endfor %}
+{%   endfor %}
+
+{%   for af in ['ipv4','ipv6'] if vdata.af[af] is defined %}
+!
+ address-family {{ af }} unicast
+   redistribute connected
+{%     if 'ospf' in vdata %}
+   redistribute ospf {{ vdata.vrfidx }}
+{%     endif %}
+{%   endfor %}
+
+{% endfor %}

--- a/netsim/ansible/templates/vrf/dellos10.j2
+++ b/netsim/ansible/templates/vrf/dellos10.j2
@@ -1,0 +1,6 @@
+{% for vname,vdata in vrfs.items() if 'ospf' in vdata %}
+{%   include 'dellos10.ospfv2-vrf.j2' %}
+{% endfor %}
+{% if bgp.as is defined %}
+{% include 'dellos10.bgp.j2' %}
+{% endif %}

--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -1,5 +1,6 @@
 router ospf {{ vdata.vrfidx }} vrf {{ vname }}
   router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
+  redistribute connected
 {% if bgp.as is defined %}
  redistribute bgp {{ bgp.as }}
 {% endif %}

--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -1,0 +1,32 @@
+router ospf {{ vdata.vrfidx }} vrf {{ vname }}
+  router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
+{% if bgp.as is defined %}
+ redistribute bgp {{ bgp.as }}
+{% endif %}
+{% if ospf.reference_bandwidth is defined %}
+ auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
+{% endif %}
+
+{% if 'ipv4' in loopback %}
+interface loopback{{ vdata.vrfidx }}
+ ip ospf {{ vdata.vrfidx }} area {{ vdata.ospf.area|default(ospf.area) }}
+{% endif %}
+!
+{% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
+interface {{ l.ifname }}
+! {{ l.name|default("") }}
+ ip ospf {{ vdata.vrfidx }} area {{ l.ospf.area }}
+{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
+ ip ospf network {{ l.ospf.network_type }}
+{%   endif %}
+{%   if l.ospf.cost is defined %}
+ ip ospf cost {{ l.ospf.cost }}
+{%   endif %}
+{%   if l.ospf.bfd|default(False) %}
+ ip ospf bfd all-neighbors
+{%   endif %}
+{%   if l.ospf.passive|default(False) %}
+ ip ospf passive
+{%   endif %}
+!
+{% endfor %}

--- a/netsim/install/libvirt/dellos10.txt
+++ b/netsim/install/libvirt/dellos10.txt
@@ -1,0 +1,47 @@
+Creating initial configuration for Dell OS10
+=============================================
+
+* Wait for the 'login' prompt, and then wait again some more minutes
+* Login as 'admin' (password: 'admin')
+* Disable zero-touch ('ztd cancel')
+* Enter configuration mode ('configure')
+* Copy-paste the following configuration
+
+NOTE: the management traffic is isolated in a dedicated management VRF (management).
+
+===============
+*** WARNING ***
+===============
+To disable zero-touch (ZTD) a full reload is required after the first configuration.
+
+=============================================
+!
+interface mgmt1/1/1
+  no ip address dhcp
+  no ipv6 address
+  exit
+!
+ip vrf management
+  interface management
+  exit
+!
+interface mgmt1/1/1
+  no shutdown
+  ip address dhcp
+  exit
+!
+service simple-password
+username vagrant password vagrant role sysadmin priv-lvl 15
+username vagrant sshkey "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+!
+end
+write memory
+!
+! reload cycle is required to disable ZTD
+!
+reload
+!
+=============================================
+
+* Wait until the reload is completed
+* Disconnect from console (ctrl-] usually works).

--- a/netsim/templates/provider/libvirt/dellos10-domain.j2
+++ b/netsim/templates/provider/libvirt/dellos10-domain.j2
@@ -1,0 +1,13 @@
+    {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    {{ name }}.ssh.insert_key = false
+    {{ name }}.ssh.shell = "show version"
+    {{ name }}.vm.guest = :freebsd
+    {{ name }}.vm.boot_timeout = 600
+
+    {{ name }}.vm.provider :libvirt do |domain|
+      domain.disk_bus = 'ide'
+      domain.cpus = 2
+      domain.memory = 2048
+      domain.nic_model_type = "e1000"
+      domain.driver = "kvm"
+    end

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -629,6 +629,12 @@ devices:
     mgmt_if: mgmt1/1/1
     libvirt:
       image: dell/os10
+      create:
+        virt-install --connect=qemu:///system --name=vm_box --arch=x86_64 --cpu host --vcpus=2 --hvm
+          --ram=2048 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+          --disk path=vm.qcow2,format=qcow2,bus=sata
+          --disk path=hdb_OS10-installer.qcow2,format=qcow2,bus=virtio
+          --disk path=hdc_OS10-platform-S4128F.qcow2,format=qcow2,bus=virtio
     group_vars:
       ansible_network_os: dellos10
       ansible_connection: network_cli

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -33,7 +33,7 @@ attributes:
 # Built-in module defaults
 #
 bgp:
-  supported_on: [ cumulus, cumulus_nvue, eos, frr, csr, iosv, nxos, vsrx, vyos, routeros, srlinux, sros, none ]
+  supported_on: [ cumulus, cumulus_nvue, eos, frr, csr, iosv, nxos, vsrx, vyos, routeros, srlinux, sros, none, dellos10 ]
   ebgp_role: external
   advertise_roles: [ stub ]
   advertise_loopback: True
@@ -60,7 +60,7 @@ isis:
 
 ospf:
   area: 0.0.0.0
-  supported_on: [ arcos, cumulus, cumulus_nvue, eos, fortios, frr, csr, iosv, nxos, vsrx, vyos, routeros, srlinux, sros, none ]
+  supported_on: [ arcos, cumulus, cumulus_nvue, eos, fortios, frr, csr, iosv, nxos, vsrx, vyos, routeros, srlinux, sros, none, dellos10 ]
   attributes:
     global: [ af, area, process, reference_bandwidth, bfd ]
     node: [ af, area, process, reference_bandwidth, bfd, router_id ]
@@ -111,7 +111,7 @@ evpn: # Enables the EVPN address family towards BGP peers
     global: [ use_ibgp ]
 
 vrf: # Basic VRF support
-  supported_on: [ eos, iosv, csr, routeros ]
+  supported_on: [ eos, iosv, csr, routeros, dellos10 ]
   as: 65000
   attributes:
     global: [ as ]
@@ -623,6 +623,18 @@ devices:
       ansible_user: vagrant
       ansible_ssh_pass: vagrant
   graphite.icon: router
+
+  dellos10:
+    interface_name: ethernet1/1/%d
+    mgmt_if: mgmt1/1/1
+    libvirt:
+      image: dell/os10
+    group_vars:
+      ansible_network_os: dellos10
+      ansible_connection: network_cli
+      ansible_user: vagrant
+      ansible_ssh_pass: vagrant
+  graphite.icon: switch
 
   routeros:
     interface_name: ether%d

--- a/tests/integration/dellos10.yml
+++ b/tests/integration/dellos10.yml
@@ -1,0 +1,45 @@
+---
+defaults:
+  device: dellos10
+
+vrfs:
+  common:
+    import: [ red, blue, common ]
+  blue:
+    import: [ blue, common ]
+  red:
+    import: [ red, common ]
+
+
+nodes:
+  core1:
+    module: [ bgp, ospf, vrf ]
+    bgp.as: 65000
+  aggr1:
+    module: [ ospf ]
+  aggr2:
+    module: [ bgp ]
+    bgp.as: 65111
+    bgp.originate: [ 100.64.0.0/24 ]
+  host1:
+    module: []
+    device: linux
+  host2:
+    module: []
+    device: linux
+  server:
+    module: []
+    device: linux
+
+links:
+- core1: { vrf: red }
+  aggr1:
+- core1: { vrf: blue }
+  aggr2:
+- aggr1:
+  host1:
+  ospf.cost: 22
+- aggr2:
+  host2:
+- core1: { vrf: common }
+  server:


### PR DESCRIPTION
**Support for Dell OS10 NOS**, with:

- initial config
- config fetch
- BGP (ipv4/ipv6)
- OSPF (v2/v3)
- VRF (VRF-Lite)
- Libvirt install documentation
- Integration testing topology
