### PR TITLE
VyOS: Support for MPLS (and MPLS L3VPN)

### DIFF
--- a/docs/module/mpls.md
+++ b/docs/module/mpls.md
@@ -27,6 +27,7 @@ The following table describes per-platform support of individual MPLS label dist
 | Cisco IOS             |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
 | Cisco IOS XE          |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
 | Mikrotik CHR RouterOS |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
+| VyOS                  |   ✅  |   ✅    |   ❌  |   ❌  |   ❌  |
 
 **Notes:**
 * LDP is enabled on all non-VRF intra-AS interfaces with IPv4 addresses.
@@ -40,6 +41,7 @@ The following table describes per-platform support of individual MPLS label dist
 | Cisco IOS             |   ✅   |    ✅   |    ❌    |
 | Cisco IOS XE          |   ✅   |    ✅   |    ❌    |
 | Mikrotik CHR RouterOS |   ❌   |    ❌   |    ❌    |
+| VyOS                  |   ❌   |    ❌   |    ❌    |
 
 **Notes**
 * Cisco IOS merges labeled and unlabeled BGP routes.
@@ -54,6 +56,7 @@ The following table describes per-platform support of individual MPLS label dist
 | Cisco IOS             |   ✅  |   ✅  |
 | Cisco IOS XE          |   ✅  |   ✅  |
 | Mikrotik CHR RouterOS |   ✅  |   ❌  |
+| VyOS                  |   ✅  |   ✅  |
 
 **Notes**
 * VPNv4 and VPNv6 address families are enabled on IPv4 IBGP/EBGP sessions

--- a/netsim/ansible/templates/mpls/vyos.j2
+++ b/netsim/ansible/templates/mpls/vyos.j2
@@ -1,0 +1,23 @@
+#!/bin/vbash
+source /opt/vyatta/etc/functions/script-template
+
+if [ "$(id -g -n)" != 'vyattacfg' ] ; then
+    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
+fi
+
+# Configuration items start here
+configure
+
+# MPLS: {{ mpls }}
+{% if ldp is defined %}
+{%   include 'vyos.ldp.j2' +%}
+{% endif %}
+{% if mpls.vpn is defined %}
+{%   include 'vyos.mplsvpn.j2' +%}
+{% endif %}
+
+# Commit, save and exit from subshell
+
+commit
+save
+exit

--- a/netsim/ansible/templates/mpls/vyos.ldp.j2
+++ b/netsim/ansible/templates/mpls/vyos.ldp.j2
@@ -1,0 +1,17 @@
+{% if 'ipv4' in loopback %}
+set protocols mpls ldp discovery transport-ipv4-address {{ loopback.ipv4|ipaddr('address') }}
+{% endif %}
+
+set protocols mpls ldp router-id {{ ldp.router_id }}
+
+{% if ldp.explicit_null|default(False) %}
+set protocols mpls ldp export ipv4 explicit-null
+{% endif %}
+
+set protocols mpls interface dum0
+set protocols mpls ldp interface dum0
+
+{% for l in interfaces if ('ldp' in l) and not l.ldp.passive %}
+set protocols mpls interface {{ l.ifname }}
+set protocols mpls ldp interface {{ l.ifname }}
+{% endfor %}

--- a/netsim/ansible/templates/mpls/vyos.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/vyos.mplsvpn.j2
@@ -1,0 +1,15 @@
+{% for af in ['ipv4','ipv6'] if mpls.vpn[af] is defined %}
+{%   set vpnaf = 'vpn' + af.replace('ip','') %}
+{%   for n in bgp.neighbors if n[vpnaf] is defined %}
+# Activate BGP AFI {{ vpnaf }} -> {{ af }}-vpn for VyOS NEIGH: {{ n[vpnaf] }}
+set protocols bgp neighbor {{ n[vpnaf] }} address-family {{ af }}-vpn
+
+{%     if bgp.next_hop_self is defined and bgp.next_hop_self %}
+set protocols bgp neighbor {{ n[vpnaf] }} address-family {{ af }}-vpn nexthop-self
+{%     endif %}
+{%     if bgp.rr|default('') and not n.rr|default('') %}
+set protocols bgp neighbor {{ n[vpnaf] }} address-family {{ af }}-vpn route-reflector-client
+{%     endif %}
+
+{%   endfor %}
+{% endfor %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -112,6 +112,7 @@ evpn: # Enables the EVPN address family towards BGP peers
 
 vrf: # Basic VRF support
   supported_on: [ eos, iosv, csr, routeros, dellos10, vyos ]
+  config_after: [ ospf, isis, bgp, mpls ]
   as: 65000
   attributes:
     global: [ as ]
@@ -120,7 +121,7 @@ vrf: # Basic VRF support
     interface: str
 
 mpls: # LDP and BGP LU support
-  supported_on: [ eos, iosv, csr, routeros ]
+  supported_on: [ eos, iosv, csr, routeros, vyos ]
   config_after: [ ospf, isis, bgp ]
   transform_after: [ bgp ]
   ldp: True
@@ -622,6 +623,10 @@ devices:
       ansible_connection: paramiko
       ansible_user: vagrant
       ansible_ssh_pass: vagrant
+    features:
+      mpls:
+        ldp: True
+        vpn: True
   graphite.icon: router
 
   dellos10:


### PR DESCRIPTION
@ipspace **WARNING**: 

I had to add to the **vrf** module the following (otherwise frr on vyos does not correctly handle the service label):
```
  config_after: [ ospf, isis, bgp, mpls ]
```
It seems to me that also *logically* this ordering is fine.
A did a quick test of a L3VPN topology with *vyos* (of course ;) ), *csr*, *eos*, *chr*, and everything looked good.
Do you see any other issue with that change?
