### PR TITLE
Update linux.j2 - fix for Alpine

### DIFF
--- a/netsim/ansible/templates/initial/linux.j2
+++ b/netsim/ansible/templates/initial/linux.j2
@@ -14,7 +14,7 @@ SCRIPT
 # This is annoying on a network with filtered DNS.
 # DNSMasq server used for giving out DHCP addresses on the management network is able to act as a DNS Server.
 # Let's use that.
-
+{% if ansible_connection != "docker" %}
 # (Overwrite netplan config to remove DNS stuff)
 cat <<SCRIPT >/etc/netplan/01-netcfg.yaml
 network:
@@ -40,7 +40,7 @@ DNSStubListener=yes
 SCRIPT
 
 systemctl restart systemd-resolved
-
+{% endif %}
 #
 # Build hosts file
 #


### PR DESCRIPTION
Hi,
with clab/docker as provider, Linux hosts are using the image `python:3.9-alpine` but that triggers some issues due to the absence of `netplan` and `systemd`.

This is a quick-and-dirty fix to keep things working with Alpine, but maybe we should implement a routine to deal with the flavor of images pulled (alpine/debian/ubuntu/rh). Replacing `python:3.9-alpine` with an official ubuntu images required the install of python.

Julien