### PR TITLE
Preliminary work for VRF and Cumulus NVUE

### DIFF
--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -43,7 +43,7 @@
 {%     endif %}
 {%       if l.vrf is defined %}
           vrf: {{ l.vrf }}
-{% endif %}
+{%       endif %}
 {%     if l.ipv6 is defined %}
 {%       if l.ipv6 == True %}
 {%       else %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -41,6 +41,9 @@
             {{ l.ipv4 }}: {}
 {%       endif %}
 {%     endif %}
+{%       if l.vrf is defined %}
+          vrf: {{ l.vrf }}
+{% endif %}
 {%     if l.ipv6 is defined %}
 {%       if l.ipv6 == True %}
 {%       else %}

--- a/netsim/ansible/templates/vrf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vrf/cumulus_nvue.j2
@@ -1,0 +1,6 @@
+- set:
+{% for vname,vdata in vrfs.items() %}
+    vrf:
+      {{ vname }}:
+        table: auto
+{% endfor %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -111,7 +111,7 @@ evpn: # Enables the EVPN address family towards BGP peers
     global: [ use_ibgp ]
 
 vrf: # Basic VRF support
-  supported_on: [ eos, iosv, csr, routeros, dellos10, vyos ]
+  supported_on: [ eos, iosv, csr, routeros, dellos10, vyos, cumulus_nvue ]
   config_after: [ ospf, isis, bgp, mpls ]
   as: 65000
   attributes:


### PR DESCRIPTION
Hi,
I couldn't finish the full implementation for VRF, but this commit enable VRF-lite for CL5 (nvue).

```
provider: clab
name: toto

vrfs:
  RED:
  blue:

nodes:
  spine01:
    device: cumulus_nvue
  leaf01:
    device: cumulus_nvue
    module: [ vrf ]

links:
- leaf01: { vrf: RED }
  spine01:
```

```
root@leaf01:/# nv config show
- set:
    system:
      hostname: leaf01
    vrf:
      RED:
        table: auto
[...]
      swp1:
        description: leaf01 -> spine01
        ip:
          address:
            10.1.0.1/30: {}
          vrf: RED
```
```
ubuntu@oob-mgmt-server:~$ docker exec -it clab-toto-spine01 ping -c2 10.1.0.1
PING 10.1.0.1 (10.1.0.1) 56(84) bytes of data.
64 bytes from 10.1.0.1: icmp_seq=1 ttl=64 time=0.118 ms
64 bytes from 10.1.0.1: icmp_seq=2 ttl=64 time=0.064 ms
```