### PR TITLE
Debian compatibility and general cleanup

### DIFF
--- a/netsim/install/ansible.sh
+++ b/netsim/install/ansible.sh
@@ -15,11 +15,23 @@ during the installation process.
 =====================================================================
 
 EOM
+
+# Add sudo / root check - ghostinthenet 20220418
+SUDO=''
+if [ "$UID" != "0" ]; then
+ if [ -x "$(command -v sudo)" ]; then
+  SUDO=sudo
+ else
+  echo 'Script requires root privileges.'
+  exit 0
+ fi
+fi
+
 if [[ -z "$FLAG_YES" ]]; then
-  read -p "Are you sure you want to proceed [Y/n] " -n 1 -r
+  # Remove implied default of Y - ghostinthenet 20220418
+  read -p "Are you sure you want to proceed [y/n] " -n 1 -r
   echo
-  # Original script didn't properly accept an empty response as a default Y - ghostinthenet 20220417
-  if ! [[ $REPLY =~ ^$|[Yy] ]]; then
+  if ! [[ $REPLY =~ [Yy] ]]; then
    echo "Aborting..."
    exit 1
   fi
@@ -33,25 +45,25 @@ IGNORE="--ignore-installed"
 # Install Python components
 #
 echo "Install baseline Python components"
-sudo pip3 install $REPLACE $IGNORE $FLAG_PIP testresources pyyaml httplib2
-sudo pip3 install $REPLACE $IGNORE $FLAG_PIP jinja2 six bracket-expansion netaddr
+$SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP testresources pyyaml httplib2
+$SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP jinja2 six bracket-expansion netaddr
 #
 echo "Install Ansible Python dependencies"
 echo ".. pynacl lxml"
-sudo pip3 install $REPLACE $IGNORE $FLAG_PIP pynacl lxml
+$SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP pynacl lxml
 echo ".. paramiko netmiko"
-sudo pip3 install $REPLACE $FLAG_PIP paramiko netmiko
+$SUDO pip3 install $REPLACE $FLAG_PIP paramiko netmiko
 #
 echo "Install optional Python components"
-sudo pip3 install $REPLACE $FLAG_PIP textfsm ttp jmespath ntc-templates
+$SUDO pip3 install $REPLACE $FLAG_PIP textfsm ttp jmespath ntc-templates
 #
 echo "Install nice-to-have Python software"
-sudo pip3 install $REPLACE $FLAG_PIP yamllint yq
+$SUDO pip3 install $REPLACE $FLAG_PIP yamllint yq
 #
 # Install latest Ansible version with pip
 #
 echo "Installing Ansible"
-sudo pip3 install $REPLACE $FLAG_PIP ansible
+$SUDO pip3 install $REPLACE $FLAG_PIP ansible
 #
 echo
 echo "Installation complete. Let's test Ansible version"

--- a/netsim/install/ansible.sh
+++ b/netsim/install/ansible.sh
@@ -18,11 +18,12 @@ EOM
 if [[ -z "$FLAG_YES" ]]; then
   read -p "Are you sure you want to proceed [Y/n] " -n 1 -r
   echo
-  FLAG_YES="$REPLY"
-fi
-if [[ ! $FLAG_YES =~ ^[Yy]$ ]]; then
-  echo "Aborting..."
-  exit 1
+  # Original script didn't properly accept an empty response as a default Y - ghostinthenet 20220417
+  if ! [[ $REPLY =~ ^$|[Yy] ]]; then
+   echo "Aborting..."
+   exit 1
+  fi
+  FLAG_YES="Y"
 fi
 #
 set -e

--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -2,8 +2,8 @@
 cat <<EOM
 Docker/Containerlab Installation Script
 =====================================================================
-This script installs Docker and containerlab on a Ubuntu system.
-The script was tested on Ubuntu 20.04.
+This script installs Docker and containerlab on a Debian or Ubuntu
+system. The script was tested on Debian 11.3 and Ubuntu 20.04.
 
 NOTE: the script is set to abort on first error. If the installation
 completed you're probably OK even though you might have seen errors
@@ -14,12 +14,14 @@ EOM
 if [[ -z "$FLAG_YES" ]]; then
   read -p "Are you sure you want to proceed [Y/n] " -n 1 -r
   echo
-  FLAG_YES="$REPLY"
+  # Original script didn't properly accept an empty response as a default Y - ghostinthenet - 20220417
+  if ! [[ $REPLY =~ ^$|[Yy] ]]; then
+   echo "Aborting..."
+   exit 1
+  fi
+  FLAG_YES="Y"
 fi
-if [[ ! $FLAG_YES =~ ^[Yy]$ ]]; then
-  echo "Aborting..."
-  exit 1
-fi
+#
 set -e
 REPLACE="--upgrade"
 IGNORE="--ignore-installed"
@@ -31,13 +33,29 @@ echo
 echo "Install support software"
 sudo apt-get install -y $FLAG_QUIET ca-certificates curl gnupg lsb-release
 echo "Install Docker GPG key and set up Docker repository"
+# Begin code to identify distribution and populate DISTRIBUTION variable - ghostinthenet - 20220417
+if [ -f /etc/debian_version ]; then
+ if [ -f /etc/lsb-release ]; then
+  if [[ $(grep DISTRIB_ID /etc/lsb-release | awk -F'=' '{print $2;}') == 'Ubuntu' ]]; then
+   DISTRIBUTION='ubuntu'
+  fi
+ else
+  DISTRIBUTION='debian'
+ fi
+else
+ echo 'Installed distribution is neither Debian nor Ubuntu. Aborting...'
+ exit 1
+fi
+# End code to identify distribution and populate DISTRIBUTION variable - ghostinthenet - 20220417
 set +e
 sudo rm /usr/share/keyrings/docker-archive-keyring.gpg 2>/dev/null
+# Re-referenced to default APT GPG keyring directory - ghostinthenet - 20220417
+sudo rm /etc/apt/trusted.gpg.d/docker-archive-keyring.gpg 2>/dev/null
 set -e
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+# Added DISTRIBUTION variable and re-referenced to default APT GPG keyring directory - ghostinthenet - 20220417
+curl -fsSL https://download.docker.com/linux/$DISTRIBUTION/gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/docker-archive-keyring.gpg
+# Added DISTRIBUTION variable and removed custom APT GPG keychain source - ghostinthenet - 20220417
+echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$DISTRIBUTION $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 #
 echo "Install Docker Engine"
 sudo apt-get update

--- a/netsim/install/ubuntu.sh
+++ b/netsim/install/ubuntu.sh
@@ -11,11 +11,23 @@ during the installation process.
 =====================================================================
 
 EOM
+
+# Add sudo / root check - ghostinthenet 20220418
+SUDO=''
+if [ "$UID" != "0" ]; then
+ if [ -x "$(command -v sudo)" ]; then
+  SUDO=sudo
+ else
+  echo 'Script requires root privileges.'
+  exit 0
+ fi
+fi
+
 if [[ -z "$FLAG_YES" ]]; then
-  read -p "Are you sure you want to proceed [Y/n] " -n 1 -r
+  # Remove implied default of Y - ghostinthenet 20220418
+  read -p "Are you sure you want to proceed [y/n] " -n 1 -r
   echo
-  # Original script didn't properly accept an empty response as a default Y - ghostinthenet - 20220417
-  if ! [[ $REPLY =~ ^$|[Yy] ]]; then
+  if ! [[ $REPLY =~ [Yy] ]]; then
    echo "Aborting..."
    exit 1
   fi
@@ -27,23 +39,23 @@ set -e
 # Comment the next line if you want to have verbose installation messages
 #
 echo "Update package list and upgrade the existing packages"
-sudo apt-get update -y $FLAG_QUIET 
-sudo apt-get upgrade -y $FLAG_APT
+$SUDO apt-get update -y $FLAG_QUIET 
+$SUDO apt-get upgrade -y $FLAG_APT
 #
 # Install missing packages
 #
 echo "Install missing packages (also a pretty long operation)"
 # Added curl, which is not installed by default on Debian - ghostinthenet - 20220417
-sudo apt-get -y $FLAG_APT install python3 python3-setuptools ifupdown python3-pip curl
+$SUDO apt-get -y $FLAG_APT install python3 python3-setuptools ifupdown python3-pip curl
 echo "Install nice-to-have packages"
-sudo apt-get -y $FLAG_APT install git ack-grep jq tree sshpass colordiff
+$SUDO apt-get -y $FLAG_APT install git ack-grep jq tree sshpass colordiff
 #
 # Install Ansible and NAPALM dependencies
 #
 echo "Install Python development and build modules"
-sudo apt-get -y $FLAG_APT install build-essential python3-dev libffi-dev
+$SUDO apt-get -y $FLAG_APT install build-essential python3-dev libffi-dev
 echo "Installing XML libraries"
-sudo apt-get -y $FLAG_APT install libxslt1-dev libssl-dev
+$SUDO apt-get -y $FLAG_APT install libxslt1-dev libssl-dev
 echo
 echo "Installation complete."
 echo

--- a/netsim/install/ubuntu.sh
+++ b/netsim/install/ubuntu.sh
@@ -14,12 +14,14 @@ EOM
 if [[ -z "$FLAG_YES" ]]; then
   read -p "Are you sure you want to proceed [Y/n] " -n 1 -r
   echo
-  FLAG_YES="$REPLY"
+  # Original script didn't properly accept an empty response as a default Y - ghostinthenet - 20220417
+  if ! [[ $REPLY =~ ^$|[Yy] ]]; then
+   echo "Aborting..."
+   exit 1
+  fi
+  FLAG_YES="Y"
 fi
-if [[ ! $FLAG_YES =~ ^[Yy]$ ]]; then
-  echo "Aborting..."
-  exit 1
-fi
+#
 set -e
 #
 # Comment the next line if you want to have verbose installation messages
@@ -31,7 +33,8 @@ sudo apt-get upgrade -y $FLAG_APT
 # Install missing packages
 #
 echo "Install missing packages (also a pretty long operation)"
-sudo apt-get -y $FLAG_APT install python3 python3-setuptools ifupdown python3-pip
+# Added curl, which is not installed by default on Debian - ghostinthenet - 20220417
+sudo apt-get -y $FLAG_APT install python3 python3-setuptools ifupdown python3-pip curl
 echo "Install nice-to-have packages"
 sudo apt-get -y $FLAG_APT install git ack-grep jq tree sshpass colordiff
 #


### PR DESCRIPTION
Summary of changes:

- Corrected all scripts to accept an empty response as Y
- Added Debian/Ubuntu distribution detection in containerlab.sh to add the correct docker repository
- Re-referenced Docker APT GPG key and APT source definition in containerlab.sh to use the APT trusted.gpg.d directory
- Removed deprecated use of "apt-key add" and "add-apt-repository" in libvirt.sh and replaced it with current mechanism
- Added curl to missing packages in ubuntu.sh as this is not installed by default in Debian

To-do:

Deal with the fact that sudo is not installed by default on Debian. Scripts test successfully on Debian 10/11 as long as sudo is installed and configured or if run as root. Scripts test successfully on Ubuntu 20/21.