### PR TITLE
Linux/Ubuntu persistent net provisioning

### DIFF
--- a/netsim/ansible/templates/initial/linux.j2
+++ b/netsim/ansible/templates/initial/linux.j2
@@ -10,7 +10,26 @@ cat <<SCRIPT >/root/.bash_profile
 export PS1="\h(bash)$ "
 SCRIPT
 
-{% if 'ubuntu' in box %}
+#
+# Build hosts file
+#
+hostname {{ inventory_hostname }}
+awk '/127.0.1.1/,/^$/' /etc/hosts >/tmp/hosts
+echo "127.0.0.1 {{ inventory_hostname }}" >>/tmp/hosts
+{% for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) %}
+echo "{%- if v.loopback.ipv4 is defined %}{{ v.loopback.ipv4|ipaddr('address') }} {% endif %}
+{%- for l in v.interfaces|default([]) if 'ipv4' in l and l.ipv4 != True and l.ipv4|ipv4 %}{{ l.ipv4|ipaddr('address') }} {% endfor %}{{ k }}" >>/tmp/hosts
+{% endfor %}
+cat /etc/hosts | awk '/localhost/,/^$/' >/tmp/hosts-start
+{% if ansible_connection != "docker" %}
+mv /tmp/hosts-start /etc/hosts
+{% endif %}
+sort /tmp/hosts|uniq >>/etc/hosts
+
+{#
+# Ubuntu tweaks and persistence (hostnamectl and netplan)
+#}
+{% if 'ubuntu' in box and ansible_connection != "docker" %}
 # It seems on the Vagrant box for ubuntu 20.04, DNS Servers are hardcoded as 4.2.2.1 & Co.
 # This is annoying on a network with filtered DNS.
 # DNSMasq server used for giving out DHCP addresses on the management network is able to act as a DNS Server.
@@ -41,23 +60,10 @@ DNSStubListener=yes
 SCRIPT
 
 systemctl restart systemd-resolved
-{% endif %}
-#
-# Build hosts file
-#
-hostname {{ inventory_hostname }}
-awk '/127.0.1.1/,/^$/' /etc/hosts >/tmp/hosts
-echo "127.0.0.1 {{ inventory_hostname }}" >>/tmp/hosts
-{% for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) %}
-echo "{%- if v.loopback.ipv4 is defined %}{{ v.loopback.ipv4|ipaddr('address') }} {% endif %}
-{%- for l in v.interfaces|default([]) if 'ipv4' in l and l.ipv4 != True and l.ipv4|ipv4 %}{{ l.ipv4|ipaddr('address') }} {% endfor %}{{ k }}" >>/tmp/hosts
-{% endfor %}
-cat /etc/hosts | awk '/localhost/,/^$/' >/tmp/hosts-start
-{% if ansible_connection != "docker" %}
-mv /tmp/hosts-start /etc/hosts
-{% endif %}
-sort /tmp/hosts|uniq >>/etc/hosts
-{% if ansible_connection != "docker" %}
+
+# Set persistent hostname
+hostnamectl set-hostname {{ inventory_hostname }}
+
 #
 # Enable LLDP
 #
@@ -68,8 +74,90 @@ configure lldp tx-interval 30
 configure lldp tx-hold 3
 configure system interface pattern *,!eth0,eth*
 CONFIG
-service lldpd restart
+systemctl enable lldpd
+systemctl restart lldpd
+
+# Sysctl
+cat <<SCRIPT > /etc/sysctl.d/10-netsim.conf
+net.ipv4.ip_forward=0
+net.ipv6.conf.all.forwarding=0
+
+{%   if loopback.ipv6 is defined %}
+net.ipv6.conf.lo.disable_ipv6=0
+{%   endif %}
+{% for l in interfaces|default([]) %}
+{%   if l.ipv6 is defined %}
+net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
+{%   endif %}
+{% endfor %}
+
+SCRIPT
+sysctl -p /etc/sysctl.d/10-netsim.conf
+
+# Loopback addressing
+{% if loopback.ipv4 is defined or loopback.ipv6 is defined %}
+cat <<SCRIPT > /etc/netplan/02-loopback.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lo:
+      addresses:
+{%   if 'ipv4' in loopback %}
+        - {{ loopback.ipv4 }}
+{%   endif %}
+{%   if 'ipv6' in loopback %}
+        - {{ loopback.ipv6 }}
+{%   endif %}
+SCRIPT
 {% endif %}
+
+# Interface addressing
+{% for l in interfaces|default([]) if (l.ipv4 is defined or l.ipv6 is defined)%}
+cat <<SCRIPT > /etc/netplan/03-eth-{{ l.ifname }}.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    {{ l.ifname }}:
+      addresses:
+{% if l.ipv4 is defined %}
+        - {{ l.ipv4 }}
+{%   endif %}
+{% if l.ipv6 is defined %}
+        - {{ l.ipv6 }}
+{%   endif %}
+{% if l.mtu is defined %}
+      mtu: {{ l.mtu }}
+{% endif %}
+SCRIPT
+{% endfor %}
+
+# Add routes to IPv4 address pools pointing to the first neighbor on the first link
+{% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
+cat <<SCRIPT > /etc/netplan/04-routes-{{ ifdata.ifname }}.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    {{ ifdata.ifname }}:
+      routes:
+{%   for name,pool in pools.items()|default({}) %}
+{%     for af,pfx in pool.items() if af == 'ipv4' and name != 'mgmt' and name != 'router_id' %}
+        - to: {{ pfx }}
+          via: {{ ifdata.gateway.ipv4|ipaddr('address') }}
+{%     endfor %}
+{%   endfor %}
+SCRIPT
+{% endfor  %}
+
+netplan generate
+netplan apply
+
+{% else %}
+
+### One-Shot configuration (non-Ubuntu VM or container)
+
 #
 # Disable IPv4 and IPv6 forwarding
 #
@@ -122,7 +210,7 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 #
 {% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
 {%   for name,pool in pools.items()|default({}) %}
-{%     for af,pfx in pool.items() if af == 'ipv4' %}
+{%     for af,pfx in pool.items() if af == 'ipv4' and name != 'mgmt' and name != 'router_id' %}
 set +e
 ip route del {{ pfx }} 2>/dev/null
 set -e
@@ -130,3 +218,4 @@ ip route add {{ pfx }} via {{ ifdata.gateway.ipv4|ipaddr('address') }}
 {%     endfor %}
 {%   endfor %}
 {% endfor  %}
+{% endif %}


### PR DESCRIPTION
Set network&sysctl stuff persistent across reboot with Ubuntu kind of VM.

This check is being used:
```
{% if 'ubuntu' in box and ansible_connection != "docker" %}
```
*LLDP* installation (which uses *apt*), and DNS tweaks for Ubuntu image have been moved under this *if*.

The patch has been tested against:
* Ubuntu 20.04 VM (Libvirt provider)
* python:3.9-alpine Container (CLAB provider)

Additionally, skipping *mgmt* and *router_id* pools in static routing configuration.