### PR TITLE
[Fix] Cumulus NVUE daemon start error on libvirt

### DIFF
--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -6,7 +6,8 @@
 
 - block:
   - name: "Start NVUE daemon"
-    command: sudo systemctl start nvued
+    command: systemctl start nvued
+    become: true
 
   - name: "Wait for nvued to start"
     service_facts:

--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -6,7 +6,7 @@
 
 - block:
   - name: "Start NVUE daemon"
-    command: systemctl start nvued
+    command: sudo systemctl start nvued
 
   - name: "Wait for nvued to start"
     service_facts:


### PR DESCRIPTION
At least on my deployment with libvirt, the task "Start NVUE daemon" brutally dies with the following:

```
fatal: [s1]: FAILED! => changed=true
  cmd:
  - systemctl
  - start
  - nvued
  delta: '0:00:00.014788'
  end: '2022-04-21 10:49:43.656199'
  msg: non-zero return code
  rc: 4
  start: '2022-04-21 10:49:43.641411'
  stderr: |-
    Failed to start nvued.service: Access denied
    See system logs and 'systemctl status nvued.service' for details.
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```

this seems due to the fact that, on the libvirt image, the ansible login is done with the vagrant/cumulus ssh user.

Using *sudo* shall work for both the libvirt and container use case.

(I tested the patch both with libvirt and CLAB, but please @barajus give it a check as well, thanks!)
