### PR TITLE
OS10: fixes on documentation and updated image creation

### DIFF
--- a/docs/labs/dellos10.md
+++ b/docs/labs/dellos10.md
@@ -3,7 +3,7 @@
 Dell OS10 is supported by the **netlab libvirt package** command.
 
 ```{warning}
-Dell provides the OS10 Virtual image as a set of vmdk and gns3a files to be used within GNS3, and only for the main release track (i.e., 10.5.2.0). The following procedure will "convert" the required files for using them with Vagrant, and also allows to inject a specific build release into the image (the image is based on a ONIE installer).
+Dell provides the OS10 Virtual image as a set of vmdk and gns3a files to be used within GNS3. The following procedure will "convert" the required files for using them with Vagrant.
 ```
 
 To prepare for the build:
@@ -13,27 +13,11 @@ To prepare for the build:
 * Convert these *vmdk* files into *qcow2* format with *qemu-img* utility:
   * OS10-Disk-1.0.0.vmdk
   * OS10-Installer-`<VERSION>`.vmdk
-  * OS10-platform-S4128F-`<VERSION>`.vmdk
+  * OS10-platform-`<PLATFORM>`-`<VERSION>`.vmdk
 ```
 qemu-img convert -O qcow2 /tmp/OS10-Disk-1.0.0.vmdk OS10-Disk-1.qcow2
-qemu-img convert -O qcow2 /tmp/OS10-Installer-10.5.2.0.229.vmdk hdb_OS10-installer.qcow2
-qemu-img convert -O qcow2 /tmp/OS10-platform-S4128F-10.5.2.0.229.vmdk hdc_OS10-platform-S4128F.qcow2
-```
-* Copy the updated Dell OS10 upgrade package (*.bin*) inside the *hdb_OS10-installer.qcow2* disk image:
-```
-modprobe nbd max_part=8
-qemu-nbd --connect=/dev/nbd0 ./hdb_OS10-installer.qcow2
-
-mount /dev/nbd0p1 /mnt/somepoint/
-
-cd /mnt/somepoint/
-cp /tmp/PKGS_OS10-Enterprise-10.5.3.4.108buster-installer-x86_64.bin os10.bin
-chmod 777 os10.bin
-md5sum os10.bin | awk '{print $1}' > image.txt
-
-cd
-umount /mnt/somepoint/
-qemu-nbd --disconnect /dev/nbd0
+qemu-img convert -O qcow2 /tmp/OS10-Installer-10.5.3.4.108.vmdk hdb_OS10-installer.qcow2
+qemu-img convert -O qcow2 /tmp/OS10-platform-S5224F-10.5.3.4.108.vmdk hdc_OS10-platform.qcow2
 ```
 
 To build a Dell OS10 box based on the above install image:

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -89,7 +89,7 @@ Configuration files for Virtualbox and KVM/libvirt environments specify the numb
 | Juniper vSRX 3.0           | vsrx               |    2 |   4096 | 
 | Mikrotik CHR RouterOS      | routeros           |    1 |    256 |
 | VyOS                       | vyos               |    2 |   1024 |
-| Dell OS10                  | vyos               |    2 |   2048 |
+| Dell OS10                  | dellos10           |    2 |   2048 |
 
 ## Configuration Deployments
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -672,7 +672,7 @@ devices:
           --ram=2048 --network=network:vagrant-libvirt,model=virtio --graphics none --import
           --disk path=vm.qcow2,format=qcow2,bus=sata
           --disk path=hdb_OS10-installer.qcow2,format=qcow2,bus=virtio
-          --disk path=hdc_OS10-platform-S4128F.qcow2,format=qcow2,bus=virtio
+          --disk path=hdc_OS10-platform.qcow2,format=qcow2,bus=virtio
     group_vars:
       ansible_network_os: dellos10
       ansible_connection: network_cli


### PR DESCRIPTION
Updated doc on image creation.
Dell seems to provide the virtual image for every single release now, so the workaround for version upgrade is no longer needed.