### PR TITLE
libvirt Vagrantfile support for node-level nic_model

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -105,8 +105,18 @@ These node attributes are recognized and used by *netsim-tools*:
 * **loopback** -- static loopback addresses. Must be a dictionary with **ipv4** and/or **ipv6** attributes.
 * **memory** -- memory allocated to the VM lab device. Not applicable for container-based devices.
 * **cpu** -- virtual CPU cores allocated to the VM lab device. Not applicable for container-based devices.
+* **nic_model** - virtual NIC model allocated to the VM lab device. Applicable only to **libvirt**. Supported values are:
+  * virtio (*libvirt default*)
+  * e1000
+  * rtl8139
+  * pcnet
+  * ne2k_pci
+  * i82559er
+  * i82557b
+  * i82551
+  * ne2k_isa
 
-[Supported Virtualization Providers](platforms.md#supported-virtualization-providers) section of [Supported Platforms](platforms.md) lists the default **memory** and **cpu** values for all devices that can be run as virtual machines.
+[Supported Virtualization Providers](platforms.md#supported-virtualization-providers) section of [Supported Platforms](platforms.md) lists the default **nic_model**, **memory** and **cpu** values for all devices that can be run as virtual machines.
 
 ## Augmenting Node Data
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -105,18 +105,41 @@ These node attributes are recognized and used by *netsim-tools*:
 * **loopback** -- static loopback addresses. Must be a dictionary with **ipv4** and/or **ipv6** attributes.
 * **memory** -- memory allocated to the VM lab device. Not applicable for container-based devices.
 * **cpu** -- virtual CPU cores allocated to the VM lab device. Not applicable for container-based devices.
-* **libvirt.nic_model** - virtual NIC model allocated to the VM lab device. Applicable only to **libvirt**. Supported values are:
-  * virtio (*libvirt default*)
-  * e1000
-  * rtl8139
-  * pcnet
-  * ne2k_pci
-  * i82559er
-  * i82557b
-  * i82551
-  * ne2k_isa
 
-[Supported Virtualization Providers](platforms.md#supported-virtualization-providers) section of [Supported Platforms](platforms.md) lists the default **nic_model**, **memory** and **cpu** values for all devices that can be run as virtual machines.
+[Supported Virtualization Providers](platforms.md#supported-virtualization-providers) section of [Supported Platforms](platforms.md) lists the default **memory** and **cpu** values for all devices that can be run as virtual machines.
+
+### Platform specific Node Attributes
+
+Some node attributes are used only within specific *netsim-tools* platforms.
+
+These attributes can be specified at node level as `<platform>.<attribute>`, or as default with `defaults.devices.<device>.<platform>.node.<attribute>`.
+
+* **libvirt**:
+  * **libvirt.nic_model** - virtual NIC model allocated to the VM lab device. Applicable only to **libvirt**. Supported values are:
+    * virtio (*libvirt default*)
+    * e1000
+    * rtl8139
+    * pcnet
+    * ne2k_pci
+    * i82559er
+    * i82557b
+    * i82551
+    * ne2k_isa
+
+Example:
+```
+---
+defaults.devices.vyos.libvirt.node.nic_model: e1000
+
+nodes:
+  vyos1:
+    device: vyos
+  vyos2:
+    device: vyos
+    libvirt.nic_model: virtio
+```
+
+[Supported Virtualization Providers](platforms.md#supported-virtualization-providers) section of [Supported Platforms](platforms.md) lists the default **nic_model** for all devices that can be run as virtual machines.
 
 ## Augmenting Node Data
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -105,7 +105,7 @@ These node attributes are recognized and used by *netsim-tools*:
 * **loopback** -- static loopback addresses. Must be a dictionary with **ipv4** and/or **ipv6** attributes.
 * **memory** -- memory allocated to the VM lab device. Not applicable for container-based devices.
 * **cpu** -- virtual CPU cores allocated to the VM lab device. Not applicable for container-based devices.
-* **nic_model** - virtual NIC model allocated to the VM lab device. Applicable only to **libvirt**. Supported values are:
+* **libvirt.nic_model** - virtual NIC model allocated to the VM lab device. Applicable only to **libvirt**. Supported values are:
   * virtio (*libvirt default*)
   * e1000
   * rtl8139

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -76,20 +76,20 @@ You cannot use all supported network devices with all virtualization providers. 
 
 Configuration files for Virtualbox and KVM/libvirt environments specify the number of virtual CPUs and memory allocated to individual network devices. These are the default values; you can change them with [node parameters](nodes.md#node-attributes).
 
-| Virtual network device     | netsim device type | CPUs | memory |
-| -------------------------- | ------------------ | ---: | -----: |
-| Arista vEOS                | eos                |    2 |   2048 |
-| Cisco IOSv                 | iosv               |    1 |    512 |
-| Cisco CSR 1000v            | csr                |    2 |   4096 | 
-| Cisco Nexus 9300v          | nxos               |    2 |   6144 [❗](caveats.html#cisco-nexus-os)| 
-| Cumulus Linux              | cumulus            |    2 |   1024 |
-| Cumulus Linux 5.0 (NVUE)   | cumulus_nvue       |    2 |   1024 |
-| Fortinet FortiOS           | fortios            |    1 |   1024 |
-| Generic Linux host         | linux              |    1 |   1024 |
-| Juniper vSRX 3.0           | vsrx               |    2 |   4096 | 
-| Mikrotik CHR RouterOS      | routeros           |    1 |    256 |
-| VyOS                       | vyos               |    2 |   1024 |
-| Dell OS10                  | dellos10           |    2 |   2048 |
+| Virtual network device     | netsim device type | CPUs | memory | libvirt NIC model          |
+| -------------------------- | ------------------ | ---: | -----: | -------------------------: |
+| Arista vEOS                | eos                |    2 |   2048 | virtio (*libvirt default*) |
+| Cisco IOSv                 | iosv               |    1 |    512 | e1000                      |
+| Cisco CSR 1000v            | csr                |    2 |   4096 | virtio (*libvirt default*) |
+| Cisco Nexus 9300v          | nxos               |    2 |   6144 [❗](caveats.html#cisco-nexus-os)| e1000 |
+| Cumulus Linux              | cumulus            |    2 |   1024 | virtio (*libvirt default*) |
+| Cumulus Linux 5.0 (NVUE)   | cumulus_nvue       |    2 |   1024 | virtio (*libvirt default*) |
+| Fortinet FortiOS           | fortios            |    1 |   1024 | virtio (*libvirt default*) |
+| Generic Linux host         | linux              |    1 |   1024 | virtio (*libvirt default*) |
+| Juniper vSRX 3.0           | vsrx               |    2 |   4096 | virtio (*libvirt default*) |
+| Mikrotik CHR RouterOS      | routeros           |    1 |    256 | virtio (*libvirt default*) |
+| VyOS                       | vyos               |    2 |   1024 | virtio (*libvirt default*) |
+| Dell OS10                  | dellos10           |    2 |   2048 | e1000                      |
 
 ## Configuration Deployments
 

--- a/netsim/templates/provider/libvirt/Vagrantfile.j2
+++ b/netsim/templates/provider/libvirt/Vagrantfile.j2
@@ -48,8 +48,8 @@ SCRIPT
 {% if 'memory' in n %}
       domain.memory = {{ n.memory }}
 {% endif %}
-{% if 'nic_model' in n %}
-      domain.nic_model_type = "{{ n.nic_model }}"
+{% if n.libvirt is defined and 'nic_model' in n.libvirt %}
+      domain.nic_model_type = "{{ n.libvirt.nic_model }}"
 {% endif %}
     end
 

--- a/netsim/templates/provider/libvirt/Vagrantfile.j2
+++ b/netsim/templates/provider/libvirt/Vagrantfile.j2
@@ -48,6 +48,9 @@ SCRIPT
 {% if 'memory' in n %}
       domain.memory = {{ n.memory }}
 {% endif %}
+{% if 'nic_model' in n %}
+      domain.nic_model_type = "{{ n.nic_model }}"
+{% endif %}
     end
 
 {%   for l in n.interfaces|default([]) if l.virtual_interface is not defined %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -28,7 +28,7 @@ attributes:
   link: [ bandwidth,bridge,name,prefix,role,type,unnumbered,interfaces,mtu,gateway,vlan_name ]
   link_internal: [ linkindex ]
   link_no_propagate: [ prefix,interfaces,gateway ]
-  node: [ role,mtu,runtime,provider,id,loopback,cpu,memory ]  # not enforced yet
+  node: [ role,mtu,runtime,provider,id,loopback,cpu,memory,nic_model ]  # not enforced yet
 
 # Built-in module defaults
 #

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -28,7 +28,7 @@ attributes:
   link: [ bandwidth,bridge,name,prefix,role,type,unnumbered,interfaces,mtu,gateway,vlan_name ]
   link_internal: [ linkindex ]
   link_no_propagate: [ prefix,interfaces,gateway ]
-  node: [ role,mtu,runtime,provider,id,loopback,cpu,memory,nic_model ]  # not enforced yet
+  node: [ role,mtu,runtime,provider,id,loopback,cpu,memory ]  # not enforced yet
 
 # Built-in module defaults
 #


### PR DESCRIPTION
It would be useful to support libvirt nic_model override at node level.

Use case example:
VyOS, but Linux in general, has problems in creating a *LACP LAG* with the *virtio* driver. For that reason, in that case the use of *e1000* is adviced.
On the other hand, *e1000* has problems with IPSec/GRE encapsulation...

So it would be useful to override that based on the specific test use case.

(@ipspace I might have been messing up the *topology-defaults* and *platforms.md* files between this and my previous PR. Sorry for this, but I prefer starting from the *dev* branch.)