### PR TITLE
Update topology-defaults.yml

### DIFF
--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -414,6 +414,7 @@ devices:
     group_vars:
       ansible_connection: docker
       ansible_network_os: frr
+      ansible_python_interpreter: auto_silent
     clab:
       image: frrouting/frr:v7.5.0
       mtu: 1500


### PR DESCRIPTION
Fix python error for FRR
`Failed to get information on remote file (/tmp/config.sh): /bin/sh: /home/ubuntu/venv2/bin/python3: not found`