### PR TITLE
Fix: EOS requires L2 VLAN definition

### DIFF
--- a/netsim/ansible/templates/vlan/eos.j2
+++ b/netsim/ansible/templates/vlan/eos.j2
@@ -1,5 +1,6 @@
 {% for vname,vdata in vlans.items() %}
 vlan {{ vdata.id }}
+ name {{ vname }}
 {% endfor +%}
 
 {% for ifdata in interfaces if ifdata.vlan is defined %}

--- a/netsim/ansible/templates/vlan/eos.j2
+++ b/netsim/ansible/templates/vlan/eos.j2
@@ -1,3 +1,7 @@
+{% for vname,vdata in vlans.items() %}
+vlan {{ vdata.id }}
+{% endfor +%}
+
 {% for ifdata in interfaces if ifdata.vlan is defined %}
 !
 interface {{ ifdata.ifname }}


### PR DESCRIPTION
When using trunk ports in EOS, it's mandatory to define *L2 VLAN*s. (Side note: it seems this is automatically created when configuring at least one port in access mode).

Status before L2 VLAN creation:
```
s1#sh ip int bri
                                                                                         Address
Interface         IP Address               Status       Protocol                  MTU    Owner
----------------- ------------------------ ------------ -------------------- ----------- -------
Loopback0         10.0.0.1/32              up           up                      65535
Management1       192.168.121.101/24       up           up                       1500
Vlan1000          172.16.3.1/24            down         lowerlayerdown           1500
Vlan1001          172.16.2.1/24            down         lowerlayerdown           1500

s1#sh int status
Port       Name     Status       Vlan     Duplex Speed  Type            Flags Encapsulation
Et1        s1 -> s2 connected    trunk    full   10G    EbraTestPhyPort
Ma1                 connected    routed   a-full a-1G   10/100/1000
```

Config:
```
s1#conf t
s1(config)#vlan 1000
s1(config-vlan-1000)#exit
s1(config)#vlan 1001
s1(config-vlan-1001)#exit
s1(config)#exit
```

Status after VLAN definition:
```
s1#sh ip int bri
                                                                                   Address
Interface         IP Address               Status       Protocol            MTU    Owner
----------------- ------------------------ ------------ -------------- ----------- -------
Loopback0         10.0.0.1/32              up           up                65535
Management1       192.168.121.101/24       up           up                 1500
Vlan1000          172.16.3.1/24            up           up                 1500
Vlan1001          172.16.2.1/24            up           up                 1500
```