### PR TITLE
Support for External Topology provider

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -52,6 +52,7 @@ See [lab topology overview](topology-overview.md) for more details.
 * [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt), including support for *veryisolated* private networks and UDP point-to-point tunnels.
 * [Vagrant VirtualBox provider](https://www.vagrantup.com/docs/providers/virtualbox)
 * [Containerlab](https://containerlab.srlinux.dev/)
+* External (*meta* virtualization provider that allows to configure with *netsim-tools* external devices (physical or virtual))
 
 You cannot use all supported network devices with all virtualization providers. These are the supported combinations (use **[netlab show images](netlab/show.md)** command to display the current system settings).
 

--- a/docs/topology-overview.md
+++ b/docs/topology-overview.md
@@ -24,7 +24,7 @@ Topology description file is a YAML file with these top-level elements:
 : Topology name -- used to name Linux bridges when using *libvirt* Vagrant plugin
 
 **provider** (optional)
-: Virtualization provider (*libvirt*, *virtualbox* or *clab*). Default value: *libvirt*.
+: Virtualization provider (*libvirt*, *virtualbox*, *clab* or *external*). Default value: *libvirt*.
 
 Sounds confusing? The following sample topology file should help you grasp the concepts. You might also want to [explore the tutorials](tutorials.md).
 

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -124,7 +124,7 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
   ifname_format = devices.get_device_attribute(node,'interface_name',defaults)
 
   ifdata.ifindex = ifindex
-  if ifname_format:
+  if ifname_format and not 'ifname' in ifdata:
     ifdata.ifname = ifname_format % ifindex
 
   pdata = devices.get_provider_data(node,defaults).get('interface',{})

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -66,6 +66,11 @@ def augment_mgmt_if(node: Box, defaults: Box, addrs: typing.Optional[Box]) -> No
       mgmt_if = ifname_format % (ifindex_offset - 1)
     node.mgmt.ifname = mgmt_if
 
+  # If the mgmt ipaddress is statically set (IPv4/IPv6)
+  # skip the address set
+  if 'ipv4' in node.mgmt or 'ipv6' in node.mgmt:
+    return
+
   if addrs:
     for af in 'ipv4','ipv6':
       pfx = af + '_pfx'

--- a/netsim/providers/external.py
+++ b/netsim/providers/external.py
@@ -1,0 +1,26 @@
+#
+# External provider module
+#
+import subprocess
+import typing
+from box import Box
+
+from . import _Provider
+from .. import common
+
+class External(_Provider):
+  def augment_node_data(self, node: Box, topology: Box) -> None:
+    common.print_verbose('Augmenting node data for External')
+    # Cleanup MGMT MAC Address (since it's useless for us)
+    node.mgmt.pop('mac',None)
+
+  def pre_start_lab(self, topology: Box) -> None:
+    common.print_verbose('pre-start hook for External')
+    print('*** Please make sure your physical topology reflects the following cabling:')
+    print('')
+    with open('external.txt', 'r') as f:
+      print(f.read())
+    print('')
+    print('*** Please make sure your physical topology reflects the above cabling.')
+    if input('Do you want to continue [Y/n]: ') != 'Y':
+      common.fatal('Aborting...')

--- a/netsim/templates/provider/external/external.j2
+++ b/netsim/templates/provider/external/external.j2
@@ -1,0 +1,27 @@
+*** EXTERNAL TOPOLOGY SUMMARY ***
+
+LAB NAME: {{ name }}
+
+PHYSICAL P2P LINKS:
+
+|-----------------|---------------|-------------|--------------------|------------------|
+| Link Name       | Origin Device | Origin Port | Destination Device | Destination Port |
+|-----------------|---------------|-------------|--------------------|------------------|
+{% for l in links if l.type=='p2p' %}
+| {{ "%-15s" | format(l.name) }} | {{ "%-13s" | format(l.left.node) }} | {{ "%-11s" | format(l.left.ifname) }} | {{ "%-18s" | format(l.right.node) }} | {{ "%-16s" | format(l.right.ifname) }} |
+|-----------------|---------------|-------------|--------------------|------------------|
+{% endfor %}
+
+
+PHYSICAL LAN LINKS:
+
+|---------------|-------------|-----------------|----------------------|
+| Origin Device | Origin Port | Link Name (NET) | Description          |
+|---------------|-------------|-----------------|----------------------|
+{% for node_name, n in nodes.items() %}
+{% for l in n.interfaces if l.type=='lan' %}
+| {{ "%-13s" | format(node_name) }} | {{ "%-11s" | format(l.ifname) }} | {{ "%-15s" | format(l.bridge) }} | {{ "%-20s" | format(l.name) }} |
+|---------------|-------------|-----------------|----------------------|
+{% endfor %}
+{% endfor %}
+{{ "\n" }}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -196,6 +196,14 @@ providers:
     cleanup: [ clab.yml ]
     bridge_type: bridge # Use 'ovs-bridge' to create Openvswitch bridges
 
+  external:
+    config: external.txt
+    template: external.j2
+    start: "echo 'Enjoy!'"
+    stop: "echo 'What?'"
+    probe: [ ]
+    cleanup: [ external.txt ]
+
 ports:
   ssh: 22
   http: 80
@@ -227,6 +235,8 @@ devices:
     virtualbox:
       image: none
     libvirt:
+      image: none
+    external:
       image: none
     group_vars:
       ansible_connection: paramiko_ssh
@@ -270,6 +280,8 @@ devices:
       vlan:
         svi_interface_name: BVI{bvi}
         vlan_subif_name: "{ifname}.{subif_index}"
+    external:
+      image: none
     graphite.icon: router
 
   csr:
@@ -308,6 +320,8 @@ devices:
       create:
         virt-install --connect=qemu:///system --name=vm_box --os-type=linux --os-variant=rhel4 --arch=x86_64 --cpu host --vcpus=1 --hvm
           --ram=4096 --disk path=vm.qcow2,bus=ide,format=qcow2 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+    external:
+      image: none
     graphite.icon: router
 
   nxos:
@@ -337,6 +351,8 @@ devices:
     libvirt:
       create_template: nxos.xml.j2
       image: cisco/nexus9300v
+    external:
+      image: none
     graphite.icon: nexus5000
 
   eos:
@@ -389,6 +405,8 @@ devices:
       create: |
         virt-install --connect=qemu:///system --name=vm_box --os-type=linux --arch=x86_64 --cpu host --vcpus=2 --hvm
           --ram=2048 --disk path=vm.qcow2,bus=ide,format=qcow2 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+    external:
+      image: none
     graphite.icon: switch
 
   fortios:
@@ -409,6 +427,8 @@ devices:
       ansible_httpapi_validate_certs: no
       ansible_httpapi_port: 80
       netsim_console_connection: ssh
+    external:
+      image: none
     graphite.icon: firewall
 
   frr:
@@ -423,6 +443,8 @@ devices:
       mtu: 1500
       node:
         kind: linux
+    external:
+      image: none
     graphite.icon: router
 
   linux:
@@ -453,6 +475,8 @@ devices:
         ansible_connection: docker
         ansible_user: root
         netlab_linux_distro: vanilla
+    external:
+      image: none
     graphite.icon: server
 
   vsrx:
@@ -486,6 +510,8 @@ devices:
         virt-install --connect=qemu:///system --name=vm_box --os-variant=freebsd10 --arch=x86_64 --cpu host --vcpus=2 --hvm
           --ram=4096 --disk path=vm.qcow2,bus=ide,format=qcow2 --disk path=bootstrap.iso,device=cdrom,bus=ide
           --boot hd --network=network:vagrant-libvirt,model=virtio --graphics none --import
+    external:
+      image: none
     graphite.icon: firewall
 
   arcos:
@@ -528,6 +554,8 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
+    external:
+      image: none
     graphite.icon: switch
 
   cumulus_nvue:
@@ -560,6 +588,8 @@ devices:
       group_vars:
         ansible_connection: docker
         ansible_user: root
+    external:
+      image: none
     graphite.icon: switch
         
   srlinux:
@@ -601,6 +631,8 @@ devices:
           ipv4: False
           ipv6: True
           network: False
+    external:
+      image: none
     graphite.icon: router
 
   sros:
@@ -647,6 +679,8 @@ devices:
         name: eth%d
       group_vars:
         sros_grpc_port: 57400
+    external:
+      image: none
     graphite.icon: router
 
   vyos:
@@ -665,6 +699,8 @@ devices:
         vpn: True
       vlan:
         svi_interface_name: "br0.{vlan}"
+    external:
+      image: none
     graphite.icon: router
 
   dellos10:
@@ -683,6 +719,8 @@ devices:
       ansible_connection: network_cli
       ansible_user: vagrant
       ansible_ssh_pass: vagrant
+    external:
+      image: none
     graphite.icon: switch
 
   routeros:
@@ -700,6 +738,8 @@ devices:
       mpls:
         ldp: True
         vpn: True
+    external:
+      image: none
     graphite.icon: router
 
 #


### PR DESCRIPTION
(reordered #269)

There might be some situations where you want to use a Network Topology external to the netsim-tools VM (i.e., a physical lab, a cloud deployment, ...)... but you want to use netsim-tools to create and push the configuration using the "standard" methodology.

This PR wants to try to address that use case.

The external provider does the following:

- allows to use a different interface name as link->node attribute
- allows to specify the management IP address of the external device
- creates a TXT file with the physical cabling required for the Lab
- it asks for confirmation of the physical configuration before starting ansible

Example *topology.yaml* file for using this provider:
```
---
provider: external

defaults:
  device: routeros

nodes:
  r1:
    mgmt.ipv4: 10.20.30.50
    mgmt.ifname: ether9
  r2:
  r3:

links:
- r1:
    ifname: sfp-1
  r2:
- r1:
  r2:
  r3:
```

Output TXT result:
```
*** EXTERNAL TOPOLOGY SUMMARY ***

LAB NAME: test_mik

PHYSICAL P2P LINKS:

|-----------------|---------------|-------------|--------------------|------------------|
| Link Name       | Origin Device | Origin Port | Destination Device | Destination Port |
|-----------------|---------------|-------------|--------------------|------------------|
| r1 - r2         | r1            | sfp-1       | r2                 | ether2           |
|-----------------|---------------|-------------|--------------------|------------------|


PHYSICAL LAN LINKS:

|---------------|-------------|-----------------|----------------------|
| Origin Device | Origin Port | Link Name (NET) | Description          |
|---------------|-------------|-----------------|----------------------|
| r1            | ether4      | test_mik_4      | r1 -> [r2,r3]        |
|---------------|-------------|-----------------|----------------------|
| r2            | ether4      | test_mik_4      | r2 -> [r1,r3]        |
|---------------|-------------|-----------------|----------------------|
| r3            | ether2      | test_mik_4      | r3 -> [r1,r2]        |
|---------------|-------------|-----------------|----------------------|

```