### PR TITLE
split should be used as .split for wider compat with Ansible

### DIFF
--- a/netsim/ansible/initial-config.ansible
+++ b/netsim/ansible/initial-config.ansible
@@ -60,7 +60,7 @@
   tags: [ module,test ]
   tasks:
   - set_fact:
-      modlist: "{{ modlist|split(',') if modlist is defined else netlab_module }}"
+      modlist: "{{ modlist.split(',') if modlist is defined else netlab_module }}"
   - include_tasks: "tasks/deploy-module.yml"
     loop: "{{ netlab_module|intersect(modlist) }}"
     loop_control:


### PR DESCRIPTION
Signed-off-by: Dinesh Dutt <dd.ps4u@gmail.com>