### PR TITLE
Support for additional loopback interfaces for VRF

### DIFF
--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -14,15 +14,15 @@ This configuration module implements the VRF planning and configuration logic an
 (module-vrf-platform-support)=
 VRFs are supported on these platforms:
 
-| Operating system      | VRF<br />config | Route<br />leaking | VRF-aware<br />OSPF | VRF-aware<br />BGP |
+| Operating system      | VRF<br />config | Route<br />leaking | VRF-aware<br />OSPF | VRF-aware<br />BGP | VRF-aware<br />Loopback |
 | --------------------- | :-: | :-: | :-: | :-: |
-| Arista EOS            | ✅  | ✅  | ✅  | ✅  |
-| Cisco IOS             | ✅  | ✅  | ✅  | ✅  |
-| Cisco IOS XE          | ✅  | ✅  | ✅  | ✅  |
-| Dell OS10             | ✅  | ✅  | ✅  | ✅  |
+| Arista EOS            | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Cisco IOS             | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Cisco IOS XE          | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Dell OS10             | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Cumulus NVUE          | ✅  |  ❌  |  ❌  |  ❌  |
-| Mikrotik CHR RouterOS | ✅  | ✅  | ✅  | ✅  |
-| VyOS                  | ✅  | ✅  | ✅  | ✅  |
+| Mikrotik CHR RouterOS | ✅  | ✅  | ✅  | ✅  |  ❌  |
+| VyOS                  | ✅  | ✅  | ✅  | ✅  | ✅  |
 
 **Notes:**
 * IS-IS cannot be run within a VRF, but the IS-IS configuration module is VRF-aware -- it will not try to configure IS-IS routing on VRF interfaces

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -30,7 +30,7 @@ interface {{ mgmt.ifname|default('mgmt1/1/1') }}
 {% for l in interfaces|default([]) %}
 interface {{ l.ifname }}
  no shutdown
-{%   if not l.ifname.startswith('vlan') %}
+{%   if l.virtual_interface is not defined %}
  no switchport
 {%   endif %}
 {% if l.vrf is defined %}

--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -48,6 +48,8 @@ set interfaces dummy dum0 address {{ loopback.ipv6 }}
 {%     else %}
 {%       set ns.ifname = brdata[0] + ' vif ' + brdata[1] %}
 {%     endif %}
+{%   elif l.ifname.startswith('dum') %}
+{%     set ns.iface_level = "dummy" %}
 {%   endif %}
 
 {% if l.name is defined %}

--- a/netsim/ansible/templates/vrf/dellos10.bgp.j2
+++ b/netsim/ansible/templates/vrf/dellos10.bgp.j2
@@ -19,6 +19,9 @@ router bgp {{ bgp.as }}
 {%     if 'ospf' in vdata %}
    redistribute ospf {{ vdata.vrfidx }}
 {%     endif %}
+{%     for n in interfaces|selectattr("vrf", "eq", vname)|selectattr("type", "eq", "loopback") if af in n %}
+   network {{ n[af]|ipaddr('0') }}
+{%     endfor %}
 {%   endfor %}
 
 {% endfor %}

--- a/netsim/ansible/templates/vrf/eos.bgp.j2
+++ b/netsim/ansible/templates/vrf/eos.bgp.j2
@@ -26,6 +26,10 @@ router bgp {{ bgp.as }}
 {%     endfor %}
 {%   endfor %}
 {%   for af in ['ipv4','ipv6'] %}
+{%     for n in interfaces|selectattr("vrf", "eq", vname)|selectattr("type", "eq", "loopback") if af in n %}
+  address-family {{ af }}
+    network {{ n[af]|ipaddr('0') }}
+{%     endfor %}
 {%     for n in vdata.bgp.neighbors|default([]) if n[af] is defined %}
 {%       if loop.index == 1 %}
   address-family {{ af }}

--- a/netsim/ansible/templates/vrf/ios.bgp.j2
+++ b/netsim/ansible/templates/vrf/ios.bgp.j2
@@ -7,6 +7,11 @@ router bgp {{ bgp.as }}
 {% if 'ospf' in vdata %}
   redistribute ospf {{ vdata.vrfidx }}
 {% endif %}
+!
+{% for n in interfaces|selectattr("vrf", "eq", vname)|selectattr("type", "eq", "loopback") if 'ipv4' in n %}
+{{   bgpcfg.bgp_network('ipv4',n.ipv4) }}
+{% endfor %}
+!
 {%   for n in vdata.bgp.neighbors|default([]) %}
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}
 {{       bgpcfg.neighbor_global(n,n[af]) }}

--- a/netsim/ansible/templates/vrf/vyos.bgp.j2
+++ b/netsim/ansible/templates/vrf/vyos.bgp.j2
@@ -20,6 +20,12 @@ set protocols bgp address-family {{ af }}-unicast redistribute connected
 {%   if vdata.ospf is defined %}
 set protocols bgp address-family {{ af }}-unicast redistribute ospf
 {%   endif %}
+
+# Define networks for VRF Loopback
+{% for n in interfaces|selectattr("vrf", "eq", vname)|selectattr("type", "eq", "loopback") if af in n %}
+{{   bgpcfg.bgp_network(af,n[af]) }}
+{% endfor %}
+
 {% endfor %}
 
 {% for n in vdata.bgp.neighbors|default([]) %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -20,6 +20,8 @@ addressing:
     start: 100
     mac: 08-4F-A9-00-00-00
   l2only:
+  vrf_loopback:
+    ipv4: 10.2.0.0/24
 
 # Global, node and link attributes
 attributes:
@@ -280,6 +282,8 @@ devices:
       vlan:
         svi_interface_name: BVI{bvi}
         vlan_subif_name: "{ifname}.{subif_index}"
+      vrf:
+        loopback_interface_name: Loopback{vrfidx}
     external:
       image: none
     graphite.icon: router
@@ -315,6 +319,8 @@ devices:
         ldp: True
         bgp: True
         vpn: True
+      vrf:
+        loopback_interface_name: Loopback{vrfidx}
     libvirt:
       image: cisco/csr1000v
       create:
@@ -386,6 +392,8 @@ devices:
         vpn: True
       vlan:
         svi_interface_name: Vlan{vlan}
+      vrf:
+        loopback_interface_name: Loopback{vrfidx}
     clab:
       interface:
         name: et%d
@@ -699,6 +707,8 @@ devices:
         vpn: True
       vlan:
         svi_interface_name: "br0.{vlan}"
+      vrf:
+        loopback_interface_name: "dum{vrfidx}"
     external:
       image: none
     graphite.icon: router
@@ -709,6 +719,8 @@ devices:
     features:
       vlan:
         svi_interface_name: vlan{vlan}
+      vrf:
+        loopback_interface_name: loopback{vrfidx}
     libvirt:
       image: dell/os10
       create:


### PR DESCRIPTION
It could be useful to have additional Loopback interfaces on the VRF scopes.

The feature uses the same tecnique of the VLAN module to define *virtual_interface* names/kind (i.e. LoopbackX), creating additional virtual links (type: *loopback*) - thus allowing "transparent" interface creation.

A new default address pool has been created for these interfaces.

Additionally, these loopback addresses are defined as *network* in the BGP sections.

A loopback interface creation was already addressed for VRF->OSPF part, so nothing was changed on OSPFv2 handling.

(In any case *redistribute connected* was already present both for BGP and OSPF - but for BGP I feel more "elegant" to announce the loopback with "network").