### PR TITLE
Add L2 vxlan for SR Linux; requires evpn

### DIFF
--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -29,6 +29,7 @@ The following table describes per-platform support of individual VXLAN features:
 | Cisco Nexus OS     | ✅  |
 | VyOS               | ✅  |
 | Dell OS10          | ✅  |
+| Nokia SR Linux     | ✅  |
 
 Notes:
 * Arista EOS and Cisco Nexus OS implement per-VLAN ingress replication lists

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -57,12 +57,15 @@ updates:
    vlan-tagging: {{ l.type in ["svi","vlan_member"] }}
    subinterface:
     index: {{ if_index }}
+{% if l.type == 'svi' and l.vlan.mode == 'bridge' %}
+    type: bridged
+{% endif %}
 {%  if if_index != '0' and l.type in ["svi","vlan_member"] %}
     vlan:
      encap:
-{%    if if_index != '1' or l.vlan is defined %}
+{%    if l.type == 'vlan_member' and l.vlan.access_id is defined %}
       single-tagged:
-       vlan-id: "{{ l.vlan.access_id if l.vlan is defined else if_index }}"
+       vlan-id: "{{ l.vlan.access_id }}"
 {%    else %}
       untagged: { }
 {%    endif %}
@@ -71,7 +74,7 @@ updates:
 {% endfor %}
 
 {% macro list_interfaces(vrf) %}
-{% for l in interfaces|default([]) if (l.type!='lan' or l.vlan is not defined) and l.vrf|default('default')==vrf %}
+{% for l in interfaces|default([]) if (l.type not in ['lan','svi'] or l.vlan is not defined) and l.vrf|default('default')==vrf %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -1,2 +1,9 @@
-{# File only needs to exist #}
-updates: []
+updates:
+{# Create mac-vrfs for L2 VLANs #}
+{% for l in interfaces|default([]) if (l.type=='lan' and l.vlan is defined) %}
+- path: network-instance[name=vlan_{{l.vlan.access}}]
+  val:
+   type: mac-vrf
+   interface:
+   - name: {{ l.ifname }}.{{ l.vlan.access_id }}
+{% endfor %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -1,0 +1,27 @@
+updates:
+{% if vxlan.vlans is defined %}
+{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%     set vlan = vlans[vname] %}
+- path: tunnel-interface[name=vxlan0]/vxlan-interface[index={{vlan.id}}]
+  val:
+   type: bridged
+   ingress:
+    vni: {{ vlan.vni }}
+   egress:
+    source-ip: use-system-ipv4-address
+- path: network-instance[name=vlan_{{vname}}]
+  val:
+   vxlan-interface:
+   - name: vxlan0.{{ vlan.id }}
+   protocols:
+    bgp-vpn:
+     bgp-instance:
+     - id: 1
+    bgp-evpn:
+     bgp-instance:
+     - id: 1
+       evi: {{ vlan.vni if vlan.vni < 65536 else (1 + vlan.vni % 65536) }}
+       ecmp: 8
+       vxlan-interface: vxlan0.{{ vlan.id }}
+{%   endfor %}
+{% endif %}

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -428,7 +428,7 @@ def sort_module_list(mods: list, mod_params: Box, secondary_sort: str = "config_
 Copy node data into interface data:
 
 For every module configured on a node, merge attributes listed in node_copy list
-from node data to interface data. 
+from node data to interface data.
 
 Example: copy node-level OSPF area into interfaces that don't have explicit area configuration.
 """
@@ -437,8 +437,8 @@ def copy_node_data_into_interfaces(topology: Box) -> None:
   for n in topology.nodes.values():
     for m in n.get('module',[]):                                 # Iterate over node modules
       if topology.defaults[m].attributes.node_copy:              # .. any copyable attributes for this module?
-        copy_attr = Box({ k: v 
-          for k,v in n.get(m,{}).items() 
+        copy_attr = Box({ k: v
+          for k,v in n.get(m,{}).items()
             if k in topology.defaults[m].attributes.node_copy }) # Build a Box of node attributes that could be copied to interfaces
         if copy_attr:                                            # .. anything to copy?
           for intf in n.get('interfaces',[]):                    # .. if so, it would be nice to merge it with interface data

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -99,8 +99,15 @@ class VXLAN(_Module):
     vxlan_domain_list: typing.Dict[str,list] = {}
 
     for name,ndata in topology.nodes.items():
-      if not 'vxlan' in ndata.get('module',[]):                     # Skip nodes without VXLAN module
+      _module = ndata.get('module',[])
+      if not 'vxlan' in _module:                     # Skip nodes without VXLAN module
         continue
+      elif ndata.vxlan.get('require_evpn',False) and not 'evpn' in _module:
+        common.error(
+          f'VXLAN module requires EVPN module on node {name}',
+          common.IncorrectValue,
+          'vxlan')
+
       if not 'vlans' in ndata:                                      # Skip VXLAN-enabled nodes without VLANs
         continue
 

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -99,15 +99,8 @@ class VXLAN(_Module):
     vxlan_domain_list: typing.Dict[str,list] = {}
 
     for name,ndata in topology.nodes.items():
-      _module = ndata.get('module',[])
-      if not 'vxlan' in _module:                     # Skip nodes without VXLAN module
+      if not 'vxlan' in ndata.get('module',[]):                     # Skip nodes without VXLAN module
         continue
-      elif ndata.vxlan.get('require_evpn',False) and not 'evpn' in _module:
-        common.error(
-          f'VXLAN module requires EVPN module on node {name}',
-          common.IncorrectValue,
-          'vxlan')
-
       if not 'vlans' in ndata:                                      # Skip VXLAN-enabled nodes without VLANs
         continue
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -154,8 +154,8 @@ vxlan: # VXLAN support
   domain: global
   flooding: static
   attributes:
-    global: [ domain, flooding, vlans, require_evpn ]
-    node: [ domain, flooding, vlans, require_evpn ]
+    global: [ domain, flooding, vlans ]
+    node: [ domain, flooding, vlans ]
 
 mpls: # LDP and BGP LU support
   supported_on: [ eos, iosv, csr, routeros, vyos ]
@@ -638,9 +638,6 @@ devices:
       srgb_range_start: 500000
       srgb_range_size: 1000
       ipv6_sid_offset: 100
-    vxlan:
-      # requires: [ vlan, evpn ]
-      require_evpn: True
     bfd:           # SR Linux supports lower BFD timers than the global default
       min_tx: 100
       min_rx: 100

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -149,13 +149,13 @@ vlan: # VLAN support
       node: [ vlans ]
 
 vxlan: # VXLAN support
-  supported_on: [ eos, nxos, vyos, dellos10 ]
+  supported_on: [ eos, nxos, vyos, dellos10, srlinux ]
   requires: [ vlan ]
   domain: global
   flooding: static
   attributes:
-    global: [ domain, flooding, vlans ]
-    node: [ domain, flooding, vlans ]
+    global: [ domain, flooding, vlans, require_evpn ]
+    node: [ domain, flooding, vlans, require_evpn ]
 
 mpls: # LDP and BGP LU support
   supported_on: [ eos, iosv, csr, routeros, vyos ]
@@ -638,6 +638,9 @@ devices:
       srgb_range_start: 500000
       srgb_range_size: 1000
       ipv6_sid_offset: 100
+    vxlan:
+      # requires: [ vlan, evpn ]
+      require_evpn: True
     bfd:           # SR Linux supports lower BFD timers than the global default
       min_tx: 100
       min_rx: 100


### PR DESCRIPTION
Addresses https://github.com/ipspace/netsim-tools/issues/324

On SR Linux, VXLAN requires EVPN; it might be more elegant to allow a per-platform override of the 'requires' attribute for a module, but for now I've added a 'requires_evpn' flag which is set to True on SR Linux