### PR TITLE
Model evpn.evi attribute in evpn module

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -7,6 +7,7 @@ The module depends on the BGP module.
 ## Parameters
 
 * global: use_ibgp - whether to enable EVPN for iBGP(True,default) or eBGP neighbors
+* vlans: evpn.evi - EVPN identifier, if not specified the VLAN id is used by default
 
 **Notes:**
 * For iBGP peering (default) any ipv4/ipv6 address families towards iBGP peers are disabled, leaving an EVPN-only session

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -20,7 +20,7 @@ updates:
     bgp-evpn:
      bgp-instance:
      - id: 1
-       evi: {{ vlan.evi }}
+       evi: {{ vlan.evpn.evi }}
        ecmp: 8
        vxlan-interface: vxlan0.{{ vlan.id }}
 {%   endfor %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -20,7 +20,7 @@ updates:
     bgp-evpn:
      bgp-instance:
      - id: 1
-       evi: {{ vlan.vni if vlan.vni < 65536 else (1 + vlan.vni % 65536) }}
+       evi: {{ vlan.evi }}
        ecmp: 8
        vxlan-interface: vxlan0.{{ vlan.id }}
 {%   endfor %}

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -3,8 +3,13 @@ import typing
 from . import _Module
 from box import Box
 from .. import common
+from vlan import vlan_link_attr
 
 class EVPN(_Module):
+
+  def module_pre_transform(self, topology: Box) -> None:
+    global vlan_link_attr
+    vlan_link_attr[ 'evi' ] = { 'type' : int, 'vlan': True, 'single': True }
 
   """
   Node pre-transform: set evpn.use_ibgp node attribute based on global setting

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -3,13 +3,8 @@ import typing
 from . import _Module
 from box import Box
 from .. import common
-from vlan import vlan_link_attr
 
 class EVPN(_Module):
-
-  def module_pre_transform(self, topology: Box) -> None:
-    global vlan_link_attr
-    vlan_link_attr[ 'evi' ] = { 'type' : int, 'vlan': True, 'single': True }
 
   """
   Node pre-transform: set evpn.use_ibgp node attribute based on global setting
@@ -26,10 +21,10 @@ class EVPN(_Module):
   def node_post_transform(self, node: Box, topology: Box) -> None:
     if node.get('vxlan') and node.vxlan.vlans:
       for vname in node.vxlan.vlans:
-        if not 'evi' in node.vlans[vname]:
+        if not 'evpn' in node.vlans[vname] or not 'evi' in node.vlans[vname].evpn:
           # Default EVI range : 1..65535 (16 bit)
-          node.vlans[vname].evi = node.vlans[vname].id # Set equal to VLAN id
-        elif node.vlans[vname].evi < 1 or node.vlans[vname].evi > 65535:
+          node.vlans[vname].evpn.evi = node.vlans[vname].id # Set equal to VLAN id
+        elif node.vlans[vname].evpn.evi < 1 or node.vlans[vname].evpn.evi > 65535:
           common.error(
             f'Invalid vlan.evi value {node.vlans[vname].evi} for VLAN {vname}',
             common.IncorrectValue,

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -19,9 +19,7 @@ class EVPN(_Module):
   Add 'evi' attribute (EVPN Instance) to VLANs that have a 'vni' attribute
   """
   def node_post_transform(self, node: Box, topology: Box) -> None:
-    if not 'evpn' in node.get('module',[]): # Skip nodes without EVPN module
-      continue
-    if node.vxlan and node.vxlan.vlans:
+    if node.get('vxlan') and node.vxlan.vlans:
       for vname in node.vxlan.vlans:
         if not 'evi' in node.vlans[vname]:
           # Default EVI range : 1..65535 (16 bit)

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -1,0 +1,33 @@
+import typing
+
+from . import _Module
+from box import Box
+from .. import common
+
+class EVPN(_Module):
+
+  """
+  Node pre-transform: set evpn.use_ibgp node attribute based on global setting
+  """
+  def node_pre_transform(self, node: Box, topology: Box) -> None:
+    use_ibgp = topology.evpn.get("use_ibgp",None)
+    node.evpn.use_ibgp = use_ibgp if isinstance(use_ibgp,bool) else topology.defaults.evpn.get("use_ibgp",True)
+
+  """
+  Node post-transform: runs after VXLAN module
+
+  Add 'evi' attribute (EVPN Instance) to VLANs that have a 'vni' attribute
+  """
+  def node_post_transform(self, node: Box, topology: Box) -> None:
+    if not 'evpn' in node.get('module',[]): # Skip nodes without EVPN module
+      continue
+    if node.vxlan and node.vxlan.vlans:
+      for vname in node.vxlan.vlans:
+        if not 'evi' in node.vlans[vname]:
+          # Default EVI range : 1..65535 (16 bit)
+          node.vlans[vname].evi = node.vlans[vname].id # Set equal to VLAN id
+        elif node.vlans[vname].evi < 1 or node.vlans[vname].evi > 65535:
+          common.error(
+            f'Invalid vlan.evi value {node.vlans[vname].evi} for VLAN {vname}',
+            common.IncorrectValue,
+            'evpn')

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -115,7 +115,7 @@ srv6:
 evpn: # Enables the EVPN address family towards BGP peers
   requires: [ bgp ]
   supported_on: [ sros, srlinux, frr ]
-  transform_after: [ vlan ]
+  transform_after: [ vlan, vxlan ]
   use_ibgp: True # Whether to use iBGP(default) or eBGP for EVPN peering
   attributes:
     global: [ use_ibgp ]

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -119,6 +119,7 @@ evpn: # Enables the EVPN address family towards BGP peers
   use_ibgp: True # Whether to use iBGP(default) or eBGP for EVPN peering
   attributes:
     global: [ use_ibgp ]
+    vlans: [ evi ]
 
 vrf: # Basic VRF support
   supported_on: [ eos, iosv, csr, routeros, dellos10, vyos, cumulus_nvue, nxos, srlinux ]

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -119,7 +119,7 @@ evpn: # Enables the EVPN address family towards BGP peers
   use_ibgp: True # Whether to use iBGP(default) or eBGP for EVPN peering
   attributes:
     global: [ use_ibgp ]
-    vlans: [ evi ]
+    vlans: [ evpn.evi ]
 
 vrf: # Basic VRF support
   supported_on: [ eos, iosv, csr, routeros, dellos10, vyos, cumulus_nvue, nxos, srlinux ]
@@ -137,7 +137,7 @@ vrf: # Basic VRF support
 vlan: # VLAN support
   supported_on: [ eos, iosv, vyos, dellos10, srlinux, none, routeros, nxos ]
   no_propagate: [ start_vlan_id, start_vni, auto_vni ]
-  vlan_no_propagate: [ id, vni, mode, pool, prefix ]
+  vlan_no_propagate: [ id, vni, mode, pool, prefix, evpn.evi ]
   start_vlan_id: 1000
   start_vni: 100000
   auto_vni: True

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -137,7 +137,7 @@ vrf: # Basic VRF support
 vlan: # VLAN support
   supported_on: [ eos, iosv, vyos, dellos10, srlinux, none, routeros, nxos ]
   no_propagate: [ start_vlan_id, start_vni, auto_vni ]
-  vlan_no_propagate: [ id, vni, mode, pool, prefix, evpn.evi ]
+  vlan_no_propagate: [ id, vni, mode, pool, prefix, evpn ]
   start_vlan_id: 1000
   start_vni: 100000
   auto_vni: True


### PR DESCRIPTION
The EVPN instance is a 16-bit identifier used in EVPN services. This PR allows the user to define an explicit value, or leave it as default ( = vlan id )