### PR TITLE
Fix VyOS new syntax for BGP System AS number

### DIFF
--- a/netsim/ansible/templates/bgp/vyos.j2
+++ b/netsim/ansible/templates/bgp/vyos.j2
@@ -10,7 +10,7 @@ fi
 
 configure
 
-set protocols bgp local-as {{ bgp.as }}
+set protocols bgp system-as {{ bgp.as }}
 
 {% if bgp.router_id|ipv4 %}
 set protocols bgp parameters router-id {{ bgp.router_id }}

--- a/netsim/ansible/templates/vrf/vyos.bgp.j2
+++ b/netsim/ansible/templates/vrf/vyos.bgp.j2
@@ -1,6 +1,6 @@
 {% import "vyos.bgp-macro.j2" as bgpcfg %}
 
-set protocols bgp local-as {{ bgp.as }}
+set protocols bgp system-as {{ bgp.as }}
 
 
 set protocols bgp address-family ipv4-unicast rd vpn export {{ vdata.rd }}


### PR DESCRIPTION
Fix #334

Tested with VyOS 1.4-rolling-202208100217

Please @ipspace consider adding the following to the next release changelog:
`This is required for working with VyOS 1.4 rolling > 20220801 (built after August, 1st 2022)`