### PR TITLE
VyOS: Updated image info and caveats

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -68,3 +68,12 @@ ansible-galaxy collection install git+https://github.com/nokia/ansible-networkin
 python3 -m pip install grpcio protobuf
 ```
 * OpenConfig support depends on a [pending PR](https://github.com/nokia/ansible-networking-collections/pull/21)
+
+## VyOS
+**netsim-tools** uses VyOS 1.4, which for now is a *rolling release* with daily builds (or custom builds).
+
+This is because the stable release (*1.3*) lacks (or has limitations on) some of the nice features we are using such as MPLS, VRF/L3VPN, EVPN, ...
+
+The use of a *rolling release* means potentially any build is broken or with regressions, even if the VyOS team is smart enough to perform some [automated smoke tests](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) and load [arbitrary configurations](https://github.com/vyos/vyos-1x/tree/current/smoketest/configs) to ensure there are no errors during config migration and system bootup.
+
+Additionally, using always the latest build published on [Vagrant Hub](https://app.vagrantup.com/vyos/boxes/current), should allow to easily track and react to any configuration syntax change (which anyway is a very rare event). In any case, if you find a mis-alignment between the VyOS config and the **netsim-tools** templates, feel free to *Open an Issue* or *Submit a PR*.

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -12,7 +12,6 @@ You have to use the following box names when installing or building the Vagrant 
 | Cisco Nexus 9300v      | cisco/nexus9300v            |
 | Fortinet FortiOS       | fortinet/fortios            |
 | Juniper vSRX 3.0       | juniper/vsrx3               |
-| VyOS                   | vyos/vyos                   |
 | Mikrotik CHR RouterOS  | mikrotik/chr                |
 | Dell OS10              | dell/os10                   |
 
@@ -23,6 +22,7 @@ The following Vagrant boxes are automatically downloaded from Vagrant Cloud when
 | Cumulus VX             | CumulusCommunity/cumulus-vx:4.4.0 |
 | Cumulus VX 5.0 (NVUE)            | CumulusCommunity/cumulus-vx:5.0.1 |
 | Generic Linux          | generic/ubuntu2004 |
+| VyOS                   | vyos/current       |
 
 ## Building Your Own Boxes
 
@@ -34,7 +34,7 @@ The following Vagrant boxes are automatically downloaded from Vagrant Cloud when
 * [Fortinet FortiOS](https://blog.petecrocker.com/post/fortinet_vagrant_libvirt/) by [Pete Crocker](https://blog.petecrocker.com/about/)
 * [Juniper vSRX 3.0](vsrx.md)
 * [Mikrotik RouterOS](http://stefano.dscnet.org/a/mikrotik_vagrant/) by [Stefano Sasso](http://stefano.dscnet.org)
-* [VyOS](https://github.com/ssasso/packer-vyos-vagrant) by [Stefano Sasso](http://stefano.dscnet.org)
+* [VyOS](https://github.com/ssasso/packer-vyos-vagrant) by [Stefano Sasso](http://stefano.dscnet.org) - if you don't want to use the one from Vagrant Cloud.
 
 **Notes:**
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -17,7 +17,7 @@ The following virtual network devices are supported by *netsim-tools*:
 | Mikrotik CHR RouterOS                     | routeros           |
 | Nokia SR Linux                            | srlinux            |
 | Nokia SR OS [❗](caveats.html#nokia-sr-os) | sros               |
-| VyOS                                      | vyos               |
+| VyOS 1.4 [❗](caveats.html#vyos)         | vyos               |
 | Dell OS10                                 | dellos10           |
 
 **Notes:**

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -736,12 +736,12 @@ devices:
     interface_name: eth%d
     mgmt_if: eth0
     libvirt:
-      image: vyos/vyos
+      image: vyos/current
     group_vars:
       ansible_network_os: vyos
       ansible_connection: paramiko
-      ansible_user: vagrant
-      ansible_ssh_pass: vagrant
+      ansible_user: vyos
+      ansible_ssh_pass: vyos
     features:
       mpls:
         ldp: True


### PR DESCRIPTION
Updated VyOS documentation for using latest image from vagrant hub, and add platform caveats based on the fact this is a rolling release.