### PR TITLE
VyOS: updates on VXLAN+EVPN IPv6

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -40,10 +40,11 @@ EVPN module supports three design paradigms:
 | Nokia SR Linux     |  ❌  | ✅  | ✅  | ✅  | ✅  |
 | Nokia SR OS        |  ❌  | ✅  | ✅  | ✅  | ✅  |
 | FRR                | ✅  | ✅  | ✅  | ✅  | ✅  |
-| VyOS               | ✅  | ✅  | ✅  | ✅  | ✅  |
+| VyOS               | ✅  | ✅  | ❌  | ✅  | ❌  |
 
 **Notes:**
 * FRR implementation is a control-plane-only implementation that can be used as a route reflector. It enables EVPN over IPv4 and/or IPv6 on configured type(s) of BGP sessions. It's expected that the other end of the session won't negotiate EVPN or IPv4 AF.
+* While VyOS itself supports IPv6 transport for VXLAN, using static flooding with the **vxlan** module, this seems not working with EVPN, where an IPv4 VTEP is always announced by **frr**.
 
 ## Parameters
 

--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -41,7 +41,7 @@ Notes:
 * **vxlan.domain** -- Ingress replication domain. Optional, default: **global**. Use this parameter when you want to build several isolated bridging domains within your lab.
 * **vxlan.flooding** -- A mechanism used to implement VXLAN flooding. Optional, default: **static**.
 * **vxlan.vlans** -- list of VLANs to be mapped into VXLAN VNIs.  Optional, defaults to all VLANs with **vni** attribute. All VLANs listed in **vxlan.vlans** list must have a **vni** attribute.
-* **use_v6_vtep** -- Use the IPv6 Loopback address as VTEP address. To be used on the devices where you need to explicitly set the local VTEP address, or with *staitc* flooding to generate the flooding list with IPv6 addresses.
+* **use_v6_vtep** -- Use the IPv6 Loopback address as VTEP address. To be used on the devices where you need to explicitly set the local VTEP address, or with *static* flooding to generate the flooding list with IPv6 addresses.
 
 The only supported value for **vxlan.flooding** parameter is **static** -- statically configured ingress replication
 

--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -33,12 +33,15 @@ The following table describes per-platform support of individual VXLAN features:
 
 Notes:
 * Arista EOS and Cisco Nexus OS implement per-VLAN ingress replication lists
+* Dell OS10 requires a IPv4 address for VXLAN.
+* Arista EOS seems not able to work with IPv6-only transport.
 
 ## Global Parameters
 
 * **vxlan.domain** -- Ingress replication domain. Optional, default: **global**. Use this parameter when you want to build several isolated bridging domains within your lab.
 * **vxlan.flooding** -- A mechanism used to implement VXLAN flooding. Optional, default: **static**.
 * **vxlan.vlans** -- list of VLANs to be mapped into VXLAN VNIs.  Optional, defaults to all VLANs with **vni** attribute. All VLANs listed in **vxlan.vlans** list must have a **vni** attribute.
+* **use_v6_vtep** -- Use the IPv6 Loopback address as VTEP address. To be used on the devices where you need to explicitly set the local VTEP address, or with *staitc* flooding to generate the flooding list with IPv6 addresses.
 
 The only supported value for **vxlan.flooding** parameter is **static** -- statically configured ingress replication
 

--- a/netsim/ansible/templates/evpn/vyos.j2
+++ b/netsim/ansible/templates/evpn/vyos.j2
@@ -12,8 +12,10 @@ configure
 set protocols bgp address-family l2vpn-evpn advertise-svi-ip
 set protocols bgp address-family l2vpn-evpn advertise-all-vni
 
-{% for n in bgp.neighbors if n.ipv4 is defined and n.evpn|default(False) %}
-set protocols bgp neighbor {{ n.ipv4 }} address-family l2vpn-evpn nexthop-self
+{% for n in bgp.neighbors if n.evpn|default(False) %}
+{%   for af in ['ipv4','ipv6'] if af in n %}
+  set protocols bgp neighbor {{ n[af] }} address-family l2vpn-evpn nexthop-self
+{%   endfor %}
 {% endfor %}
 
 # Configure VNI params

--- a/netsim/ansible/templates/vxlan/vyos.j2
+++ b/netsim/ansible/templates/vxlan/vyos.j2
@@ -14,9 +14,7 @@ configure
 
 # Create VXLAN interface
 set interfaces vxlan vxlan{{vlan.vni}} vni {{vlan.vni}}
-{%     if 'ipv4' in loopback %}
-set interfaces vxlan vxlan{{vlan.vni}} source-address {{ loopback.ipv4|ipaddr('address') }}
-{%     endif %}
+set interfaces vxlan vxlan{{vlan.vni}} source-address {{ vxlan.vtep }}
 # And set UDP port to 4789
 set interfaces vxlan vxlan{{vlan.vni}} port 4789
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -159,8 +159,10 @@ vxlan: # VXLAN support
   domain: global
   flooding: static
   attributes:
-    global: [ domain, flooding, vlans ]
+    global: [ domain, flooding, vlans, use_v6_vtep ]
     node: [ domain, flooding, vlans ]
+  no_propagate: [ use_v6_vtep ]
+  use_v6_vtep: false
 
 mpls: # LDP and BGP LU support
   supported_on: [ eos, iosv, csr, routeros, vyos ]

--- a/tests/integration/vxlan/vxlan-bridging-v6only-vyos.yml
+++ b/tests/integration/vxlan/vxlan-bridging-v6only-vyos.yml
@@ -1,0 +1,40 @@
+groups:
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+  switches:
+    members: [ s1, s2 ]
+    module: [ vlan, vxlan, ospf ]
+    device: vyos
+
+vlans:
+  red:
+    mode: bridge
+
+addressing:
+  loopback:
+    ipv4: false
+    ipv6: 2001:db8:0::/48
+  lan:
+    ipv6: 2001:db8:a::/48
+  p2p:
+    ipv4: false
+    ipv6: 2001:db8:f::/48
+
+defaults.vxlan.use_v6_vtep: true
+
+nodes:
+  h1:
+  h2:
+  s1:
+  s2:
+
+links:
+- h1:
+  s1:
+    vlan.access: red
+- h2:
+  s2:
+    vlan.access: red
+- s1:
+  s2:


### PR DESCRIPTION
Updates on VXLAN IPv6 transport support & EVPN IPv6 for signaling.

Additioanlly, a patch to allow the use of IPv6 for VTEPs has been produced (_vxlan_ module).