### PR TITLE
VyOS: add support for EVPN iBGP-over-eBGP

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -40,7 +40,7 @@ EVPN module supports three design paradigms:
 | Nokia SR Linux     |  ❌  | ✅  | ✅  | ✅  | ✅  |
 | Nokia SR OS        |  ❌  | ✅  | ✅  | ✅  | ✅  |
 | FRR                | ✅  | ✅  | ✅  | ✅  | ✅  |
-| VyOS               | ✅  | ✅  | ❌  | ✅  | ❌  |
+| VyOS               | ✅  | ✅  | ✅  | ✅  | ❌  |
 
 **Notes:**
 * FRR implementation is a control-plane-only implementation that can be used as a route reflector. It enables EVPN over IPv4 and/or IPv6 on configured type(s) of BGP sessions. It's expected that the other end of the session won't negotiate EVPN or IPv4 AF.

--- a/netsim/ansible/templates/bgp/vyos.macro.j2
+++ b/netsim/ansible/templates/bgp/vyos.macro.j2
@@ -8,18 +8,22 @@ set protocols bgp neighbor {{ ip }} description '{{ n.name }}'
 {%   if n.type == 'ibgp' %}
 set protocols bgp neighbor {{ ip }} update-source dum0
 {%   endif %}
+
+{%   if n.local_as is defined %}
+set protocols bgp neighbor {{ ip }} local-as {{ n.local_as }} no-prepend replace-as
+{%   endif %}
 {%- endmacro %}
 {#
    Address family BGP neighbor definition
 #}
 {% macro neighbor_af(n,ip,bgp,af) %}
 
-set protocols bgp neighbor {{ ip }} address-family {{ af }}-unicast
+set protocols bgp neighbor {{ ip }} address-family {{ af }}-unicast soft-reconfiguration inbound
 
 {%   if bgp.next_hop_self is defined and bgp.next_hop_self %}
 set protocols bgp neighbor {{ ip }} address-family {{ af }}-unicast nexthop-self
 {%   endif %}
-{%   if bgp.rr|default('') and not n.rr|default('') %}
+{%   if bgp.rr|default('') and not n.rr|default('') and n.type == 'ibgp' %}
   set protocols bgp neighbor {{ ip }} address-family {{ af }}-unicast route-reflector-client
 {%   endif %}
 {%- endmacro -%}

--- a/netsim/ansible/templates/evpn/vyos.j2
+++ b/netsim/ansible/templates/evpn/vyos.j2
@@ -14,7 +14,13 @@ set protocols bgp address-family l2vpn-evpn advertise-all-vni
 
 {% for n in bgp.neighbors if n.evpn|default(False) %}
 {%   for af in ['ipv4','ipv6'] if af in n %}
-  set protocols bgp neighbor {{ n[af] }} address-family l2vpn-evpn nexthop-self
+set protocols bgp neighbor {{ n[af] }} address-family l2vpn-evpn nexthop-self
+set protocols bgp neighbor {{ n[af] }} address-family l2vpn-evpn soft-reconfiguration inbound
+
+{%   if bgp.rr|default('') and not n.rr|default('') and n.type == 'ibgp' %}
+set protocols bgp neighbor {{ n[af] }} address-family l2vpn-evpn route-reflector-client
+{%   endif %}
+
 {%   endfor %}
 {% endfor %}
 

--- a/tests/integration/evpn/vxlan-bridging-ibgp-over-ebgp.yml
+++ b/tests/integration/evpn/vxlan-bridging-ibgp-over-ebgp.yml
@@ -1,0 +1,50 @@
+## Testing topology for iBGP over eBGP with VyOS
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+  switches:
+    members: [ spine, leaf1, leaf2 ]
+    device: vyos
+    module: [ vlan,vxlan,bgp,evpn ]
+
+bgp.as: 64999
+
+vlans:
+  red:
+    mode: bridge
+  blue:
+    mode: bridge
+
+plugin: [ ebgp-local_as ]
+
+nodes:
+  spine:
+    bgp:
+      underlay_as: 65000
+      rr: True
+  leaf1:
+    bgp.underlay_as: 65001
+  leaf2:
+    bgp.underlay_as: 65002
+  h1:
+  h2:
+  h3:
+  h4:
+
+links:
+- spine-leaf1
+- spine-leaf2
+- h1:
+  leaf1:
+    vlan.access: red
+- h2:
+  leaf2:
+    vlan.access: red
+- h3:
+  leaf1:
+    vlan.access: blue
+- h4:
+  leaf2:
+    vlan.access: blue


### PR DESCRIPTION
VyOS: add support for EVPN iBGP-over-eBGP, using the plugin **ebgp-local_as** by @jbemmel 