### PR TITLE
Updated docs on vagran box update, especially for VyOS

### DIFF
--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -24,6 +24,12 @@ The following Vagrant boxes are automatically downloaded from Vagrant Cloud when
 | Generic Linux          | generic/ubuntu2004 |
 | VyOS                   | vyos/current       |
 
+**NOTE**: Even if a new box version is available from Vagrant Cloud, Vagrant will only output a warning to the user letting them know an update is available. That user can choose to ignore the warning for now, or can update the box by running `vagrant box update`.
+Vagrant can not and does not automatically download the updated box and update the machine because boxes can be relatively large (See: https://www.vagrantup.com/docs/boxes/versioning).
+
+However, we recommend to periodically download the updated box for:
+* vyos/current
+
 ## Building Your Own Boxes
 
 * [Arista vEOS](eos.md)


### PR DESCRIPTION
Vagran cannot automatically upgrade already downloaded box... but I think we should recommend it, at least for `vyos/current`.