### PR TITLE
SR Linux vlan fixes

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -40,24 +40,27 @@ updates:
   val:
 {{  ip_addresses(loopback,False,True)  }}
 
-{% for l in interfaces|default([]) if (l.type=='lan' or l.vlan is not defined) %}
-- path: interface[name={{ l.ifname }}]
+{% for l in interfaces|default([]) if (l.type in ['lan','vlan_member'] or l.vlan is not defined) %}
+{% set if_name_index = l.ifname.split('.') %}
+{% set if_name = if_name_index[0] %}
+{% set if_index = if_name_index[1] if if_name_index|length > 1 else l.vlan.access_id|default(0) if l.vlan is defined else '0' %}
+{% set vlan = l.vlan.access|default(l.vlan.access_id|default('routed')|string()) if l.vlan is defined else l.ifname %}
+{% set if_desc = l.name|default( "vlan " + vlan )|replace('->','~')|regex_replace('[\\[\\]]','') %}
+- path: interface[name={{ if_name }}]
   val:
-{% if l.name is defined %}
-   description: "{{ l.name|replace('->','~')|regex_replace('[\\[\\]]','') }}{{ " ("+l.role+")" if l.role is defined else '' }}"
-{% elif l.type|default("") == "stub" %}
-   description: "Stub interface"
-{% endif %}
 {% if l.mtu is defined %} # min 1500; max 9412 for 7220, 9500 for 7250 platforms
    mtu {{ [l.mtu + 14,1500]|max }} # TODO not supported on loopback interfaces
 {% endif %}
-   vlan-tagging: {{ l.type in ["svi","vlan_member"] }}
-   subinterface:
-    index: {{ l.vlan.access_id }}
-{% if l.vlan is defined %}
-    type: {{ 'bridged' if vlans[ l.vlan.access ].mode in ['bridge','irb'] else 'routed' }}
+{% if l.subif_index is not defined %}{# Skip trunk parent interfaces #}
+{% if l.type in ["vlan_member"] %}
+   vlan-tagging: True
 {% endif %}
-{%  if l.vlan is defined and l.type in ["svi","vlan_member"] %}
+   subinterface:
+    index: {{ if_index }}
+    description: "{{ if_desc }}"
+{% if l.vlan is defined %}
+    type: {{ 'bridged' if l.vlan.access is defined and vlans[ l.vlan.access ].mode|default('irb') in ['bridge','irb'] else 'routed' }}
+{%  if l.type in ["vlan_member"] %}
     vlan:
      encap:
 {%    if l.type == 'vlan_member' and l.vlan.access_id is defined %}
@@ -66,12 +69,17 @@ updates:
 {%    else %}
       untagged: { }
 {%    endif %}
+{%  endif %}
 {% endif %}
 {{  ip_addresses(l,True,False) }}
+{% else %}
+   description: "Trunk {{ if_desc }}"
+{% endif %}
 {% endfor %}
 
 {% macro list_interfaces(vrf) %}
-{% for l in interfaces|default([]) if (l.type not in ['lan','svi'] or l.vlan is not defined) and l.vrf|default('default')==vrf %}
+{% for l in interfaces|default([]) if (l.vlan is not defined or l.vlan.mode|default('irb') == 'route') 
+   and l.subif_index is not defined and l.vrf|default('default')==vrf %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -40,11 +40,8 @@ updates:
   val:
 {{  ip_addresses(loopback,False,True)  }}
 
-{% for l in interfaces|default([]) if (l.type!='lan' or l.vlan is not defined) %}
-{% set if_name_index = l.ifname.split('.') %}
-{% set if_name = if_name_index[0] %}
-{% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}
-- path: interface[name={{ if_name }}]
+{% for l in interfaces|default([]) if (l.type=='lan' or l.vlan is not defined) %}
+- path: interface[name={{ l.ifname }}]
   val:
 {% if l.name is defined %}
    description: "{{ l.name|replace('->','~')|regex_replace('[\\[\\]]','') }}{{ " ("+l.role+")" if l.role is defined else '' }}"
@@ -56,11 +53,11 @@ updates:
 {% endif %}
    vlan-tagging: {{ l.type in ["svi","vlan_member"] }}
    subinterface:
-    index: {{ if_index }}
-{% if l.type == 'svi' and l.vlan.mode == 'bridge' %}
-    type: bridged
+    index: {{ l.vlan.access_id }}
+{% if l.vlan is defined %}
+    type: {{ 'bridged' if vlans[ l.vlan.access ].mode in ['bridge','irb'] else 'routed' }}
 {% endif %}
-{%  if if_index != '0' and l.type in ["svi","vlan_member"] %}
+{%  if l.vlan is defined and l.type in ["svi","vlan_member"] %}
     vlan:
      encap:
 {%    if l.type == 'vlan_member' and l.vlan.access_id is defined %}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -40,7 +40,7 @@ updates:
   val:
 {{  ip_addresses(loopback,False,True)  }}
 
-{% for l in interfaces|default([]) if (l.type in ['lan','vlan_member'] or l.vlan is not defined) %}
+{% for l in interfaces|default([]) if (l.type in ['lan','vlan_member','svi'] or l.vlan is not defined) %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else l.vlan.access_id|default(0) if l.vlan is defined else '0' %}
@@ -58,12 +58,12 @@ updates:
    subinterface:
     index: {{ if_index }}
     description: "{{ if_desc }}"
-{% if l.vlan is defined %}
+{% if l.vlan is defined and l.type in ["vlan_member","lan"] %}
     type: {{ 'bridged' if l.vlan.access is defined and vlans[ l.vlan.access ].mode|default('irb') in ['bridge','irb'] else 'routed' }}
 {%  if l.type in ["vlan_member"] %}
     vlan:
      encap:
-{%    if l.type == 'vlan_member' and l.vlan.access_id is defined %}
+{%    if l.vlan.access_id is defined %}
       single-tagged:
        vlan-id: "{{ l.vlan.access_id }}"
 {%    else %}

--- a/netsim/ansible/templates/ospf/srlinux.macro.j2
+++ b/netsim/ansible/templates/ospf/srlinux.macro.j2
@@ -22,7 +22,7 @@
          - interface-name: system0.0
            passive: True
 {%     endif %}
-{%     for l in vrf_interfaces if l.vlan is not defined %}
+{%     for l in vrf_interfaces if (l.vlan is not defined or l.vlan.mode|default('bridge')=='route') and l.subif_index is not defined %}
 {%     set ifname = l.ifname if '.' in l.ifname else (l.ifname+'.0') %}
 {%     if 'ospf' not in l %}
        # OSPF not configured on external interface {{ ifname }}
@@ -38,8 +38,6 @@
            passive: {{ ospf.passive | default(False) }}
 {%         if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
            interface-type: "{{ l.ospf.network_type }}"
-{%         elif l.type=='lan' %}
-           interface-type: broadcast
 {%         endif %}
            failure-detection:
             enable-bfd: {{ l.ospf.bfd|default(False) }}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -12,7 +12,7 @@ updates:
    - name: {{ l.ifname }}.{{ l.vlan.access_id }}
 {%  elif l.type in ['vlan_member'] and l.vlan is defined and l.vlan.access|default('?') == vname %}
    - name: {{ l.ifname }}
-{%  elif l.type=='svi' and l.ifname == irb_ifname and l.vlan.mode == 'irb' %}
+{%  elif l.type=='svi' and l.ifname == irb_ifname and (l.vlan is not defined or l.vlan.mode|default('irb') == 'irb') %}
    - name: {{ l.ifname }}
 {%  endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -12,7 +12,7 @@ updates:
    - name: {{ l.ifname }}.{{ l.vlan.access_id }}
 {%  elif l.type in ['vlan_member'] and l.vlan is defined and l.vlan.access|default('?') == vname %}
    - name: {{ l.ifname }}
-{%  elif l.type=='svi' and l.ifname == irb_ifname %}
+{%  elif l.type=='svi' and l.ifname == irb_ifname and l.vlan.mode == 'irb' %}
    - name: {{ l.ifname }}
 {%  endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -1,9 +1,20 @@
 updates:
-{# Create mac-vrfs for L2 VLANs #}
-{% for l in interfaces|default([]) if (l.type=='lan' and l.vlan is defined) %}
-- path: network-instance[name=vlan_{{l.vlan.access}}]
+{# Create mac-vrfs for L2 VLANs, add IRB interface if any #}
+{% if vlans is defined %}
+{% for vname,vdata in vlans.items() if vdata.mode|default('irb') != 'route' %}
+{% set irb_ifname = "irb0." + vdata.id | string() %}
+- path: network-instance[name=vlan_{{ vname }}]
   val:
    type: mac-vrf
    interface:
+{% for l in interfaces|default([]) %}
+{%  if l.type in ['lan'] and l.vlan is defined and l.vlan.access == vname %}
    - name: {{ l.ifname }}.{{ l.vlan.access_id }}
+{%  elif l.type in ['vlan_member'] and l.vlan is defined and l.vlan.access|default('?') == vname %}
+   - name: {{ l.ifname }}
+{%  elif l.type=='svi' and l.ifname == irb_ifname %}
+   - name: {{ l.ifname }}
+{%  endif %}
 {% endfor %}
+{% endfor %}
+{% endif %}

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -138,6 +138,8 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
         f'Invalid vlan.mode setting {default_fwd_mode} in {obj_name}',
         common.IncorrectValue,
         'vlan')
+  else:
+    default_fwd_mode = get_from_box(topology,'vlan.mode')         # Else get it from the topology level
 
   if not 'vlans' in obj:
     return
@@ -874,6 +876,7 @@ class VLAN(_Module):
         vlan_ifmap = create_svi_interfaces(n,topology)
         map_trunk_vlans(n,topology)
         rename_vlan_subinterfaces(n,topology)
+        validate_vlan_attributes(n,topology) # JvB: propagate 'mode' attribute to per-node VLANs
 
     for n in topology.nodes.values():
       set_svi_neighbor_list(n,topology)

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -581,6 +581,7 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
       vlan_mode = ifdata.vlan.get('mode','') or vlan_data.get('mode','')    # Get VLAN forwarding mode
       if vlan_mode == 'bridge':                                             # ... and skip IP addresses for bridging-only VLANs
         skip_attr.extend(['ipv4','ipv6'])
+        # continue  # JvB: in fact, skip creating SVI for L2-only VLANs
       vlan_ifdata = Box(                                                    # Copy non-physical interface attributes into SVI interface
         { k:v for k,v in ifdata.items() if k not in skip_attr },            # ... that will also give us IP addresses
         default_box=True,

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -676,8 +676,9 @@ devices:
           lla: True
       vlan:
         model: router
-        svi_interface_name: "vlan.{vlan}" # Not used
-        subif_name: "{ifname}.{subif_index}"
+        svi_interface_name: "irb0.{vlan}"
+        subif_name: "{ifname}.{vlan.access_id}"
+        mixed_trunk: True
       vxlan:
         requires: [ evpn ]
       ospf:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -676,7 +676,7 @@ devices:
           lla: True
       vlan:
         model: router
-        svi_interface_name: "{ifname}.{vlan}"
+        svi_interface_name: "vlan.{vlan}" # Not used
         subif_name: "{ifname}.{subif_index}"
       vxlan:
         requires: [ evpn ]

--- a/tests/integration/vlan/vlan-irb-trunk.yml
+++ b/tests/integration/vlan/vlan-irb-trunk.yml
@@ -5,7 +5,7 @@
 # * All hosts should be able to ping each other and
 #   switch interfaces in the same VLAN
 # * Hosts should be able to ping loopback address of s1
-#   but loopback address of s2 (static routes on hosts point to s1)
+#   but not loopback address of s2 (static routes on hosts point to s1)
 #
 # Please note it might take a while for the lab to work due to
 # STP learning phase

--- a/tests/integration/vlan/vlan-routed-trunk.yml
+++ b/tests/integration/vlan/vlan-routed-trunk.yml
@@ -2,7 +2,7 @@
 # A router-on-a-stick is attached to a VLAN trunk and runs OSPF
 # on all attached VLANs
 #
-# * r1, r2, and r3 should be able to ping each other
+# * r1, r2, and ros should be able to ping each other
 #
 # Please note it might take a while for the lab to work due to
 # STP and OSPF setup phase


### PR DESCRIPTION
Finally went through all the integration test cases under tests/integration/vlan and fixed all various corner cases.

Couple of notes:
* the vlan.mode attribute wasn't being propagated, this complicated the template logic
* consider not creating SVI interfaces for l2-only VLANs (could filter them out in each template, but easier to do once globally)
* trunk parent interfaces are detected when l.subif_index is defined, perhaps a type='trunk' (instead of p2p) would simplify things