### PR TITLE
Support for BGP default-originate

### DIFF
--- a/docs/plugins/ebgp.utils.md
+++ b/docs/plugins/ebgp.utils.md
@@ -1,18 +1,22 @@
 # EBGP Utilities
 
-The **ebgp.utils** plugin (contributed by Stefano Sasso) implements several EBGP nerd knobs, including: **allowas_in**, **as_override** and MD5 **password**:
+The **ebgp.utils** plugin (contributed by Stefano Sasso) implements several EBGP nerd knobs, including: **allowas_in**, **as_override**, **default_originate** and MD5 **password**:
 
 * **bgp.allowas_in** is an interface (node-to-link attachment) attribute that takes an integer value between 1 and 10. A *true* value sets it to 1.
 * **bgp.as_override** is an interface (node-to-link attachment) boolean attribute.
+* **bgp.default_originate** is an interface (node-to-link attachment) boolean attribute.
 * **bgp.password** is a link-level string attribute.
 
 The plugin includes Jinja2 templates for Cisco IOS, Arista EOS and VyOS.
 
-| Operating system         | allowas_in | as_override | password |
-| ------------------------ | :--------: | :---------: | :------: |
-| Arista EOS               |      ✅    |     ✅      |    ✅    |
-| Cisco IOS                |      ✅    |     ✅      |    ✅    |
-| VyOS                     |      ✅    |     ✅      |    ✅    |
+| Operating system         | allowas_in | as_override | password | default_originate |
+| ------------------------ | :--------: | :---------: | :------: | :---------------: |
+| Arista EOS               |      ✅    |     ✅      |    ✅    |    ✅    |
+| Cisco IOS                |      ✅    |     ✅      |    ✅    |    ✅    |
+| VyOS                     |      ✅    |     ✅      |    ✅    |    ✅    |
+
+**NOTES**:
+* VyOS always originates a defaults when *default_originate* is set. Arista EOS originates a default only if present in the routing table, unless *always* is specified.
 
 ## Test Topology
 
@@ -34,6 +38,7 @@ nodes:
 links:
 - r1:
     bgp.allowas_in: True
+    bgp.default_originate: True
   r2:
 - bgp.password: Test
   r2:

--- a/docs/plugins/ebgp.utils.md
+++ b/docs/plugins/ebgp.utils.md
@@ -4,7 +4,7 @@ The **ebgp.utils** plugin (contributed by Stefano Sasso) implements several EBGP
 
 * **bgp.allowas_in** is an interface (node-to-link attachment) attribute that takes an integer value between 1 and 10. A *true* value sets it to 1.
 * **bgp.as_override** is an interface (node-to-link attachment) boolean attribute.
-* **bgp.default_originate** is an interface (node-to-link attachment) boolean attribute.
+* **bgp.default_originate** is an interface (node-to-link attachment) attribute (True/False/*always*).
 * **bgp.password** is a link-level string attribute.
 
 The plugin includes Jinja2 templates for Cisco IOS, Arista EOS and VyOS.
@@ -22,26 +22,36 @@ The plugin includes Jinja2 templates for Cisco IOS, Arista EOS and VyOS.
 
 ```
 ---
-provider: clab
-defaults.device: eos
-module: [ bgp ]
+defaults:
+  device: eos
+
+module: [ bgp, vrf ]
 plugin: [ ebgp.utils ]
 
+vrfs:
+  red:
+  blue:
+
 nodes:
-  r1:
-    bgp.as: 65101
-  r2:
-    bgp.as: 65000
-  r3:
-    bgp.as: 65101
+  y1:
+    bgp.as: 65001
+  y2:
+    bgp.as: 65002
 
 links:
-- r1:
-    bgp.allowas_in: True
+- y1:
     bgp.default_originate: True
-  r2:
-- bgp.password: Test
-  r2:
+  y2:
+  bgp.password: TestPassword
+- y1:
+    vrf: red
+  y2:
+    vrf: red
+    bgp.allowas_in: True
+    bgp.default_originate: always
+- y1:
+    vrf: blue
+  y2:
+    vrf: blue
     bgp.as_override: True
-  r3:
 ```

--- a/netsim/extra/ebgp.utils/eos.j2
+++ b/netsim/extra/ebgp.utils/eos.j2
@@ -8,6 +8,9 @@
 {%   if n.password is defined %}
   neighbor {{ n[af] }} password {{ n.password }}
 {%   endif %}
+{%   if n.default_originate is defined and n.default_originate %}
+  neighbor {{ n[af] }} default-originate
+{%   endif %}
 {%- endmacro %}
 
 !

--- a/netsim/extra/ebgp.utils/eos.j2
+++ b/netsim/extra/ebgp.utils/eos.j2
@@ -1,4 +1,9 @@
 {% macro ebgp_neighbor(n,af) -%}
+{%   if n.default_originate is defined and n.default_originate|lower == 'always' %}
+  neighbor {{ n[af] }} default-originate always
+{%   elif n.default_originate is defined and n.default_originate %}
+  neighbor {{ n[af] }} default-originate
+{%   endif %}
 {%   if n.allowas_in is defined %}
   neighbor {{ n[af] }} allowas-in {{ n.allowas_in }}
 {%   endif %}
@@ -7,9 +12,6 @@
 {%   endif %}
 {%   if n.password is defined %}
   neighbor {{ n[af] }} password {{ n.password }}
-{%   endif %}
-{%   if n.default_originate is defined and n.default_originate %}
-  neighbor {{ n[af] }} default-originate
 {%   endif %}
 {%- endmacro %}
 
@@ -30,7 +32,7 @@ router bgp {{ bgp.as }}
 {%   for af in ['ipv4','ipv6'] %}
 {%     for n in vdata.bgp.neighbors if n[af] is defined %}
 {%       if loop.first %}
- address-family {{ af }}
+   address-family {{ af }}
 {%       endif %}
 {{       ebgp_neighbor(n,af) -}}
 {%     endfor %}

--- a/netsim/extra/ebgp.utils/ios.j2
+++ b/netsim/extra/ebgp.utils/ios.j2
@@ -39,6 +39,25 @@ router bgp {{ bgp.as }}
 {% endfor %}
 {% endif %}
 
+! Default Originate
+{% for n in bgp.neighbors if n.default_originate is defined %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined and n.default_originate %}
+ address-family {{ af }}
+  neighbor {{ n[af] }} default-originate
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{% for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%   for n in vdata.bgp.neighbors|default([]) if n.default_originate is defined %}
+{%     for af in ['ipv4','ipv6'] if n[af] is defined and n.default_originate %}
+ address-family {{ af }} vrf {{ vname }}
+  neighbor {{ n[af] }} default-originate
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+{% endif %}
+
 ! Password
 {% for n in bgp.neighbors if n.password is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}

--- a/netsim/extra/ebgp.utils/plugin.py
+++ b/netsim/extra/ebgp.utils/plugin.py
@@ -29,8 +29,6 @@ def pre_link_transform(topology: Box) -> None:
                 data.must_be_bool(parent=intf.bgp,key='as_override', path=f'links[{link.linkindex}].{intf.node}.bgp')
                 # allowas_in shall be int (force 1 if True)
                 data.must_be_int(parent=intf.bgp,key='allowas_in', path=f'links[{link.linkindex}].{intf.node}.bgp', true_value=1, min_value=1, max_value=10)
-                # default_originate shall be bool
-                data.must_be_bool(parent=intf.bgp,key='default_originate', path=f'links[{link.linkindex}].{intf.node}.bgp')
         if 'bgp' in link:
             # password
             data.must_be_string(parent=link.bgp,key='password', path=f'links[{link.linkindex}].bgp')

--- a/netsim/extra/ebgp.utils/vyos.j2
+++ b/netsim/extra/ebgp.utils/vyos.j2
@@ -43,6 +43,23 @@ set vrf name {{ vname }} protocols bgp neighbor {{ n[af] }} address-family {{ af
 {% endfor %}
 {% endif %}
 
+# Default Originate
+{% for n in bgp.neighbors if n.default_originate is defined %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined and n.default_originate %}
+set protocols bgp neighbor {{ n[af] }} address-family {{ af }}-unicast default-originate
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{% for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%   for n in vdata.bgp.neighbors|default([]) if n.default_originate is defined %}
+{%     for af in ['ipv4','ipv6'] if n[af] is defined and n.default_originate %}
+set vrf name {{ vname }} protocols bgp neighbor {{ n[af] }} address-family {{ af }}-unicast default-originate
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+{% endif %}
+
 # Password
 {% for n in bgp.neighbors if n.password is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}


### PR DESCRIPTION
Implement BGP *default-originate [always]* in `ebgp.utils` module.

Implements #354

Please @ipspace can you test the Cisco IOS part?
